### PR TITLE
tested-with

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /dist/
+.stack-work

--- a/hpack.cabal
+++ b/hpack.cabal
@@ -5,6 +5,7 @@
 name:           hpack
 version:        0.5.4
 synopsis:       An alternative format for Haskell packages
+category:       Development
 homepage:       https://github.com/sol/hpack#readme
 bug-reports:    https://github.com/sol/hpack/issues
 maintainer:     Simon Hengel <sol@typeful.net>

--- a/hpack.cabal
+++ b/hpack.cabal
@@ -1,4 +1,4 @@
--- This file has been generated from package.yaml by hpack version 0.5.3.
+-- This file has been generated from package.yaml by hpack version 0.5.4.
 --
 -- see: https://github.com/sol/hpack
 
@@ -10,6 +10,7 @@ bug-reports:    https://github.com/sol/hpack/issues
 maintainer:     Simon Hengel <sol@typeful.net>
 license:        MIT
 license-file:   LICENSE
+tested-with:    GHC==7.8.4
 build-type:     Simple
 cabal-version:  >= 1.10
 

--- a/package.yaml
+++ b/package.yaml
@@ -5,6 +5,8 @@ maintainer: Simon Hengel <sol@typeful.net>
 license: MIT
 github: sol/hpack
 
+tested-with: GHC==7.8.4
+
 ghc-options: -Wall
 
 dependencies:

--- a/package.yaml
+++ b/package.yaml
@@ -4,6 +4,7 @@ synopsis: An alternative format for Haskell packages
 maintainer: Simon Hengel <sol@typeful.net>
 license: MIT
 github: sol/hpack
+category: Development
 
 tested-with: GHC==7.8.4
 

--- a/src/Hpack/Config.hs
+++ b/src/Hpack/Config.hs
@@ -129,6 +129,7 @@ data PackageConfig = PackageConfig {
 , packageConfigMaintainer :: Maybe (List String)
 , packageConfigCopyright :: Maybe (List String)
 , packageConfigLicense :: Maybe String
+, packageConfigTestedWith :: Maybe String
 , packageConfigExtraSourceFiles :: Maybe (List FilePath)
 , packageConfigDataFiles :: Maybe (List FilePath)
 , packageConfigGithub :: Maybe Text
@@ -229,6 +230,7 @@ data Package = Package {
 , packageCopyright :: [String]
 , packageLicense :: Maybe String
 , packageLicenseFile :: Maybe FilePath
+, packageTestedWith :: Maybe String
 , packageExtraSourceFiles :: [FilePath]
 , packageDataFiles :: [FilePath]
 , packageSourceRepository :: Maybe SourceRepository
@@ -304,6 +306,7 @@ mkPackage (CaptureUnknownFields unknownFields globalOptions@Section{sectionData 
       , packageCopyright = fromMaybeList packageConfigCopyright
       , packageLicense = packageConfigLicense
       , packageLicenseFile = guard licenseFileExists >> Just "LICENSE"
+      , packageTestedWith = packageConfigTestedWith
       , packageExtraSourceFiles = extraSourceFiles
       , packageDataFiles = dataFiles
       , packageSourceRepository = sourceRepository

--- a/src/Hpack/Run.hs
+++ b/src/Hpack/Run.hs
@@ -98,6 +98,7 @@ renderPackage settings alignment existingFieldOrder Package{..} = intercalate "\
       , ("copyright", formatList packageCopyright)
       , ("license", packageLicense)
       , ("license-file", packageLicenseFile)
+      , ("tested-with", packageTestedWith)
       , ("build-type", Just "Simple")
       , ("cabal-version", Just ">= 1.10")
       ]

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,6 @@
+flags: {}
+packages:
+- '.'
+extra-deps:
+- base-compat-0.8.2
+resolver: lts-2.22

--- a/test/Hpack/ConfigSpec.hs
+++ b/test/Hpack/ConfigSpec.hs
@@ -19,7 +19,7 @@ import           Data.String.Interpolate
 import           Hpack.Config
 
 package :: Package
-package = Package "foo" "0.0.0" Nothing Nothing Nothing Nothing Nothing Nothing [] [] [] Nothing Nothing [] [] Nothing Nothing [] []
+package = Package "foo" "0.0.0" Nothing Nothing Nothing Nothing Nothing Nothing [] [] [] Nothing Nothing Nothing [] [] Nothing Nothing [] []
 
 executable :: String -> String -> Executable
 executable name main_ = Executable name main_ []


### PR DESCRIPTION
Related to https://github.com/sol/hpack/issues/40

`tested-with` is useful, as one could [generate travis build matrix](https://github.com/hvr/multi-ghc-travis/blob/master/make_travis_yml.hs) using that information.