### PR TITLE
Generates valid module names from dashed package names

### DIFF
--- a/src/Hpack/Config.hs
+++ b/src/Hpack/Config.hs
@@ -467,6 +467,12 @@ toSection a CommonOptions{..}
     cppOptions = fromMaybeList commonOptionsCppOptions
     dependencies = fromMaybeList commonOptionsDependencies
 
+moduleNameFromPkgName :: String -> String
+moduleNameFromPkgName name = map f name
+  where
+      f '-' = '_'
+      f x = x
+
 determineModules :: String -> [String] -> Maybe (List String) -> Maybe (List String) -> ([String], [String])
 determineModules name modules mExposedModules mOtherModules = case (mExposedModules, mOtherModules) of
   (Nothing, Nothing) -> (modules, [])
@@ -474,7 +480,7 @@ determineModules name modules mExposedModules mOtherModules = case (mExposedModu
   where
     otherModules   = maybe ((modules \\ exposedModules) ++ pathsModule) fromList mOtherModules
     exposedModules = maybe (modules \\ otherModules)   fromList mExposedModules
-    pathsModule = ["Paths_" ++ name] \\ exposedModules
+    pathsModule = ["Paths_" ++ moduleNameFromPkgName name] \\ exposedModules
 
 getModules :: FilePath -> FilePath -> IO [String]
 getModules dir src_ = sort <$> do

--- a/test/Hpack/ConfigSpec.hs
+++ b/test/Hpack/ConfigSpec.hs
@@ -363,6 +363,18 @@ spec = do
           |]
           (packageLibrary >>> (`shouldBe` Just (section library) {sectionSourceDirs = ["foo", "bar"]}))
 
+      it "replaces dashes with underscores in exposed-modules" $ do
+        withPackageConfig [i|
+          name: foo-bar
+          library:
+            source-dirs: src
+            exposed-modules: Foo
+          |]
+          (do
+          touch "src/Foo.hs"
+          )
+          (packageLibrary >>> (`shouldBe` Just (section library{libraryExposedModules = ["Foo"], libraryOtherModules = ["Paths_foo_bar"]}) {sectionSourceDirs = ["src"]}))
+
       it "allows to specify exposed-modules" $ do
         withPackageConfig [i|
           library:


### PR DESCRIPTION
Fixes #68 by replacing dashes with underscores. Adds a test to confirm
behaviour.