### PR TITLE
[failing] add test for adding Paths_* when no modules are specified

### DIFF
--- a/test/Hpack/ConfigSpec.hs
+++ b/test/Hpack/ConfigSpec.hs
@@ -233,6 +233,9 @@ spec = do
     it "adds the Paths_* module to the other-modules" $ do
       determineModules "foo" [] (Just $ List ["Foo"]) Nothing `shouldBe` (["Foo"], ["Paths_foo"])
 
+    it "adds the Paths_* module to the other-modules when no modules are specified" $ do
+      determineModules "foo" [] Nothing Nothing `shouldBe` ([], ["Paths_foo"])
+
     it "replaces dashes with underscores in Paths_*" $ do
       determineModules "foo-bar" [] (Just $ List ["Foo"]) Nothing `shouldBe` (["Foo"], ["Paths_foo_bar"])
 


### PR DESCRIPTION
This PR adds a failing test, don't merge yet.

(I don't know whether I'll find the time to work on this. Maybe we try to use the github 'Assignee' to avoid duplicate efforts.)
