### PR TITLE
Allow custom file name instead of package.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /dist/
+.stack-work/

--- a/src/Hpack.hs
+++ b/src/Hpack.hs
@@ -34,9 +34,9 @@ import           Hpack.Run
 programVersion :: Version -> String
 programVersion v = "hpack version " ++ Version.showVersion v
 
-header :: Version -> String
-header v = unlines [
-    "-- This file has been generated from " ++ packageConfig ++ " by " ++ programVersion v ++ "."
+header :: Version -> FileName -> String
+header v file = unlines [
+    "-- This file has been generated from " ++ file ++ " by " ++ programVersion v ++ "."
   , "--"
   , "-- see: https://github.com/sol/hpack"
   , ""
@@ -49,6 +49,7 @@ main = do
     ["--version"] -> putStrLn (programVersion version)
     ["--help"] -> printHelp
     _ -> case parseVerbosity args of
+      (verbose, [dir, fname]) -> hpackWithName fname dir verbose
       (verbose, [dir]) -> hpack dir verbose
       (verbose, []) -> hpack "" verbose
       _ -> do
@@ -58,8 +59,11 @@ main = do
 printHelp :: IO ()
 printHelp = do
   hPutStrLn stderr $ unlines [
-      "Usage: hpack [ --silent ] [ dir ]"
+      "Usage: hpack [ --silent ] [ dir [ file ] ]"
     , "       hpack --version"
+    , "       "
+    , "  dir:  directorty containing your package description file"
+    , "  file: name of your package description file (default is package.yaml)"
     ]
 
 parseVerbosity :: [String] -> (Bool, [String])
@@ -86,9 +90,15 @@ parseVersion xs = case [v | (v, "") <- readP_to_S Version.parseVersion xs] of
 hpack :: FilePath -> Bool -> IO ()
 hpack = hpackWithVersion version
 
+hpackWithName :: FileName -> FilePath -> Bool -> IO ()
+hpackWithName file = hpackWithVersionAndFileName file version
+
 hpackWithVersion :: Version -> FilePath -> Bool -> IO ()
-hpackWithVersion v dir verbose = do
-  (warnings, name, new) <- run dir
+hpackWithVersion = hpackWithVersionAndFileName "package.yaml"
+
+hpackWithVersionAndFileName :: FileName -> Version -> FilePath -> Bool -> IO ()
+hpackWithVersionAndFileName file v dir verbose = do
+  (warnings, name, new) <- run dir file
   forM_ warnings $ \warning -> hPutStrLn stderr ("WARNING: " ++ warning)
 
   old <- either (const Nothing) (Just . splitHeader) <$> tryJust (guard . isDoesNotExistError) (readFile name >>= (return $!!))
@@ -98,7 +108,7 @@ hpackWithVersion v dir verbose = do
     if (fmap snd old == Just (lines new)) then do
       output (name ++ " is up-to-date")
     else do
-      (writeFile name $ header v ++ new)
+      (writeFile name $ header v file ++ new)
       output ("generated " ++ name)
   else do
     output (name ++ " was generated with a newer version of hpack, please upgrade and try again.")

--- a/src/Hpack.hs
+++ b/src/Hpack.hs
@@ -94,7 +94,7 @@ hpackWithName :: FileName -> FilePath -> Bool -> IO ()
 hpackWithName file = hpackWithVersionAndFileName file version
 
 hpackWithVersion :: Version -> FilePath -> Bool -> IO ()
-hpackWithVersion = hpackWithVersionAndFileName "package.yaml"
+hpackWithVersion = hpackWithVersionAndFileName packageConfig
 
 hpackWithVersionAndFileName :: FileName -> Version -> FilePath -> Bool -> IO ()
 hpackWithVersionAndFileName file v dir verbose = do

--- a/src/Hpack/Config.hs
+++ b/src/Hpack/Config.hs
@@ -17,6 +17,7 @@ module Hpack.Config (
 , packageDependencies
 , package
 , section
+, FileName
 , Package(..)
 , Dependency(..)
 , AddSource(..)
@@ -61,6 +62,8 @@ import           System.FilePath
 import           Hpack.GenericsUtil
 import           Hpack.Util
 import           Hpack.Yaml
+
+type FileName = String
 
 package :: String -> String -> Package
 package name version = Package name version Nothing Nothing Nothing Nothing Nothing Nothing [] [] [] Nothing Nothing Nothing [] [] [] Nothing Nothing [] [] []

--- a/src/Hpack/Run.hs
+++ b/src/Hpack/Run.hs
@@ -33,9 +33,9 @@ import           Hpack.Config
 import           Hpack.Render
 import           Hpack.FormattingHints
 
-run :: FilePath -> IO ([String], FilePath, String)
-run dir = do
-  mPackage <- readPackageConfig (dir </> packageConfig)
+run :: FilePath -> FileName -> IO ([String], FilePath, String)
+run dir file = do
+  mPackage <- readPackageConfig (dir </> file)
   case mPackage of
     Right (warnings, pkg) -> do
       let cabalFile = dir </> (packageName pkg ++ ".cabal")


### PR DESCRIPTION
@sol 

Following https://github.com/commercialhaskell/stack/issues/2011
and https://github.com/commercialhaskell/stack/issues/2001

hpack is great, but I was a bit annoyed in my projects because

  - stack access several time a same cabal file for some operations => hpack is run too often for me
  - there is too much logging by default (dozen of line per rebuild when many subprojects) but in the same time, I'm not sure less logging is better.
  - I have dozen of files package.yaml in my editor file tree (because all subproject have one) and it's a bit more annoying to find the right one than if I had files with different names.
  - stack maintainer don't really value adding a disable hpack flag (which I totally understand)
  - I cant move easilly my package description file elsewhere because of hpack internal (and I don't really want to because of folder organisation)

So, I made a small patch that allow one to specify a custom package description name instead of using the default "package.yaml" name. This way, I can solve all my problems: stack don't know anymore I'm using hpack, I can run hpack only when I want (with something like that: https://atom.io/packages/save-commands, it's rather painless)

implementation note:
I tried not to change the API used by stack, so no modification have to done on the stack project