### PR TITLE
Fix build on ghc-8

### DIFF
--- a/src/Hpack/Config.hs
+++ b/src/Hpack/Config.hs
@@ -52,7 +52,7 @@ import           Data.Ord
 import           Data.String
 import           Data.Text (Text)
 import qualified Data.Text as T
-import           GHC.Generics
+import           GHC.Generics (Generic, Rep)
 import           Prelude ()
 import           Prelude.Compat
 import           System.Directory


### PR DESCRIPTION
Due to addition of https://ghc.haskell.org/trac/ghc/ticket/10030 , which is ambiguous with `Hpack.Config.packageName`