### PR TITLE
test/Helper.hs: fix build with GHC 8.0.1

### DIFF
--- a/test/Helper.hs
+++ b/test/Helper.hs
@@ -10,17 +10,17 @@ module Helper (
 import           Test.Hspec
 import           Test.Mockery.Directory
 import           Control.Applicative
-import           System.Directory
+import qualified System.Directory as Dir
 import           Control.Exception
 import qualified System.IO.Temp as Temp
 import           System.FilePath
 
 withCurrentDirectory :: FilePath -> IO a -> IO a
 withCurrentDirectory dir action = do
-  bracket (getCurrentDirectory) (setCurrentDirectory) $ \ _ -> do
-    setCurrentDirectory dir
+  bracket (Dir.getCurrentDirectory) (Dir.setCurrentDirectory) $ \ _ -> do
+    Dir.setCurrentDirectory dir
     action
 
 withTempDirectory :: (FilePath -> IO a) -> IO a
 withTempDirectory action = Temp.withSystemTempDirectory "hspec" $ \dir -> do
-  canonicalizePath dir >>= action
+  Dir.canonicalizePath dir >>= action


### PR DESCRIPTION
It'd be great to do a minor release to Hackage with this change so that this package can be added back to Stackage.  This is currently the only thing blocking adding `stack` back into Stackage since the GHC 8.0.1 upgrade.