### PR TITLE
Support optionally-exposed modules

### DIFF
--- a/hpack.cabal
+++ b/hpack.cabal
@@ -30,6 +30,8 @@ library
     , filepath
     , Glob
     , text
+    , transformers
+    , transformers-compat
     , containers
     , unordered-containers
     , yaml
@@ -43,8 +45,10 @@ library
       Hpack.FormattingHints
       Hpack.GenericsUtil
       Hpack.Haskell
+      Hpack.OptionalExposure
       Hpack.Render
       Hpack.Util
+      Hpack.VersionRange
       Paths_hpack
   default-language: Haskell2010
 
@@ -61,6 +65,8 @@ executable hpack
     , filepath
     , Glob
     , text
+    , transformers
+    , transformers-compat
     , containers
     , unordered-containers
     , yaml
@@ -84,6 +90,8 @@ test-suite spec
     , filepath
     , Glob
     , text
+    , transformers
+    , transformers-compat
     , containers
     , unordered-containers
     , yaml
@@ -100,17 +108,21 @@ test-suite spec
       Hpack.FormattingHintsSpec
       Hpack.GenericsUtilSpec
       Hpack.HaskellSpec
+      Hpack.OptionalExposureSpec
       Hpack.RenderSpec
       Hpack.RunSpec
       Hpack.UtilSpec
+      Hpack.VersionRangeSpec
       HpackSpec
       Hpack
       Hpack.Config
       Hpack.FormattingHints
       Hpack.GenericsUtil
       Hpack.Haskell
+      Hpack.OptionalExposure
       Hpack.Render
       Hpack.Run
       Hpack.Util
+      Hpack.VersionRange
       Hpack.Yaml
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -16,6 +16,8 @@ dependencies:
   - filepath
   - Glob
   - text
+  - transformers
+  - transformers-compat
   - containers
   - unordered-containers
   - yaml

--- a/src/Hpack/Config.hs
+++ b/src/Hpack/Config.hs
@@ -59,6 +59,7 @@ import           System.Directory
 import           System.FilePath
 
 import           Hpack.GenericsUtil
+import           Hpack.OptionalExposure (OptionalExposure(..))
 import           Hpack.Util
 import           Hpack.Yaml
 
@@ -105,15 +106,6 @@ genericParseJSON_ = genericParseJSON defaultOptions {fieldLabelModifier = hyphen
     name :: String
     name = typeName (Proxy :: Proxy a)
 
-hyphenize :: String -> String -> String
-hyphenize name =
-#if MIN_VERSION_aeson(0,10,0)
-  camelTo2
-#else
-  camelTo
-#endif
-  '-' . drop (length name) . dropWhile (== '_')
-
 type FieldName = String
 
 class HasFieldNames a where
@@ -156,6 +148,7 @@ data LibrarySection = LibrarySection {
 , librarySectionExposedModules :: Maybe (List String)
 , librarySectionOtherModules :: Maybe (List String)
 , librarySectionReexportedModules :: Maybe (List String)
+, librarySectionOptionallyExposed :: Maybe (List OptionalExposure)
 } deriving (Eq, Show, Generic)
 
 instance HasFieldNames LibrarySection
@@ -190,6 +183,7 @@ data CommonOptions = CommonOptions {
 , commonOptionsBuildable :: Maybe Bool
 , commonOptionsWhen :: Maybe (List ConditionalSection)
 , commonOptionsBuildTools :: Maybe (List Dependency)
+, commonOptionsOptionallyExposed :: Maybe (List OptionalExposure)
 } deriving (Eq, Show, Generic)
 
 instance HasFieldNames CommonOptions
@@ -371,6 +365,7 @@ data Library = Library {
 , libraryExposedModules :: [String]
 , libraryOtherModules :: [String]
 , libraryReexportedModules :: [String]
+, libraryOptionallyExposed :: [OptionalExposure]
 } deriving (Eq, Show)
 
 data Executable = Executable {
@@ -572,9 +567,14 @@ toLibrary dir name globalOptions library = traverse fromLibrarySection sect
     fromLibrarySection :: LibrarySection -> IO Library
     fromLibrarySection LibrarySection{..} = do
       modules <- concat <$> mapM (getModules dir) sourceDirs
-      let (exposedModules, otherModules) = determineModules name modules librarySectionExposedModules librarySectionOtherModules
+      let optionalExposures = fromMaybeList librarySectionOptionallyExposed
+          modules' = modules \\ foldMap (fromList . optionalExposureModules)
+                                        optionalExposures
+          (exposedModules, otherModules) = determineModules name modules' librarySectionExposedModules librarySectionOtherModules
           reexportedModules = fromMaybeList librarySectionReexportedModules
-      return (Library librarySectionExposed exposedModules otherModules reexportedModules)
+
+      return (Library librarySectionExposed exposedModules otherModules reexportedModules
+                      optionalExposures)
 
 toExecutables :: FilePath -> Section global -> [(String, Section ExecutableSection)] -> IO [Section Executable]
 toExecutables dir globalOptions executables = mapM toExecutable sections
@@ -621,7 +621,7 @@ mergeSections globalOptions options
 
 toSection :: a -> CommonOptions -> ([FieldName], Section a)
 toSection a CommonOptions{..}
-  = ( concat unknownFields 
+  = ( concat unknownFields
     , Section {
         sectionData = a
       , sectionSourceDirs = fromMaybeList commonOptionsSourceDirs

--- a/src/Hpack/OptionalExposure.hs
+++ b/src/Hpack/OptionalExposure.hs
@@ -1,0 +1,131 @@
+{-# LANGUAGE BangPatterns, DeriveGeneric, FlexibleContexts, LambdaCase,
+             TupleSections #-}
+-- | Conditionally-exposed modules whose availability depends on the
+-- presence of other packages in the build plan.
+module Hpack.OptionalExposure (
+  OptionalExposure(optionalExposureDependencies, optionalExposureModules),
+  mkOptionalExposure, optionallyExposed,
+  readBuildPlan, BuildPlan(..)) where
+import Prelude ()
+import Prelude.Compat
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.Except (ExceptT(ExceptT), runExceptT)
+import Data.Aeson (FromJSON(..), fromJSON, genericParseJSON, defaultOptions)
+import Data.Aeson.Types (Result(..), fieldLabelModifier)
+import Data.Char (isSpace)
+import Data.Map (Map)
+import qualified Data.Map.Strict as M
+import GHC.Generics (Generic)
+import Hpack.Util (List(fromList), hyphenize)
+import Hpack.VersionRange
+import System.IO
+
+data OptionalExposure = OptionalExposure {
+  optionalExposureDependencies :: List String
+, optionalExposureModules :: List String
+, optionalExposureConstraints :: [(PackageName, VersionRange)]
+}
+
+instance Show OptionalExposure where
+  show (OptionalExposure deps mods _) =
+    "OptionalExposure (" ++ show deps ++ ") (" ++ show mods ++ ")"
+
+instance Eq OptionalExposure where
+  OptionalExposure deps mods _ == OptionalExposure deps' mods' _ =
+    deps == deps' && mods == mods'
+
+-- | An internal data type used for JSON parsing since the
+-- OptionalExposure data type carries some derived data.
+data SimpleOptionalExposure = SimpleOptionalExposure {
+  _simpleOptionalExposureDependencies :: List String
+, _simpleOptionalExposureModules :: List String
+} deriving Generic
+
+instance FromJSON SimpleOptionalExposure where
+  parseJSON = genericParseJSON
+                defaultOptions {fieldLabelModifier =
+                                  hyphenize "SimpleOptionalExposure"}
+
+instance FromJSON OptionalExposure where
+  parseJSON js = case fromJSON js of
+                   Success (SimpleOptionalExposure deps mods) ->
+                     maybe (fail "Couldn't parse optional-exposure")
+                           pure
+                           (mkOptionalExposure deps mods)
+                   Error e -> fail e
+
+-- | @mkOptionalExposure dependencyNames optionallyExposedModules@
+-- builds an 'OptionalExposure' that can be added to a package
+-- definition dependent on a build plan (see 'optionallyExposed').
+mkOptionalExposure ::  List String -> List String -> Maybe OptionalExposure
+mkOptionalExposure deps modules =
+  OptionalExposure deps modules <$>
+  mapM parseCabalDependency (fromList deps)
+
+newtype PackageName = PackageName (String) deriving (Eq,Ord,Show)
+
+data BuildPlan = MinimalBuildPlan
+               | MaximalBuildPlan
+               | BuildPlan (Map PackageName Version)
+     deriving (Eq, Show)
+
+-- * Cabal Version Ranges
+
+parseCabalDependency :: String -> Maybe (PackageName, VersionRange)
+parseCabalDependency ln =
+  case break isSpace ln of
+    (pkg,v) -> (PackageName pkg,) <$> parseVersionRange v
+
+-- * Optional Exposure
+
+-- | Returns a list of dependencies and exposed modules given a
+-- 'BuildPlan' and an 'OptionalExposure'. This acts as a filter on
+-- whether or not the 'BuildPlan' satisfies the 'OptionalExposure''s
+-- dependencies.
+optionallyExposed :: BuildPlan -> OptionalExposure -> ([String], [String])
+optionallyExposed MinimalBuildPlan _ = ([], [])
+optionallyExposed MaximalBuildPlan oe =
+  let deps = fromList $ optionalExposureDependencies oe
+      exposeds = fromList $ optionalExposureModules oe
+  in (deps, exposeds)
+optionallyExposed (BuildPlan bp) oe
+  | all available (optionalExposureConstraints oe) =
+      let deps = fromList $ optionalExposureDependencies oe
+          exposeds = fromList $ optionalExposureModules oe
+      in (deps, exposeds)
+  | otherwise = ([],[])
+  where available (pkgName, vrange) = case M.lookup pkgName bp of
+                                              Nothing -> False
+                                              Just v -> vrange v
+
+-- * Helpers
+
+unfoldM :: Monad m => m (Maybe a) -> (a -> b -> b) -> b -> m b
+unfoldM gen f z = go z
+  where go !acc = gen >>= \case
+          Nothing -> return acc
+          Just x -> go (f x acc)
+
+-- * Build Plan Parsing
+
+-- | Parse \"foo 0.1.5\" into @(PackageName "foo", Version [0,1,5])@.
+parseDep :: String -> Either String (PackageName, Version)
+parseDep ln =
+  case break isSpace ln of
+    (pkg, ' ':v) -> case parseVersion v of
+                      Just v' -> Right (PackageName pkg, v')
+                      Nothing -> Left $ "Couldn't parse version "++ln
+    _ -> Left $ "Couldn't parse dependency: " ++ ln
+
+-- | Parse a file in which each line is a package name, a whitespace
+-- character, then a version into a 'BuildPlan'.
+readBuildPlan :: FilePath -> IO (Either String BuildPlan)
+readBuildPlan f =
+  withFile f ReadMode $ \h ->
+    let getLn = do eof <- hIsEOF h
+                   if eof then return Nothing else Just <$> hGetLine h
+        parseDep' :: Applicative m
+                  => String -> ExceptT String m (PackageName, Version)
+        parseDep' = ExceptT . pure . parseDep
+    in fmap (fmap BuildPlan) . runExceptT $
+       unfoldM (lift getLn >>= traverse parseDep') (uncurry M.insert) mempty

--- a/src/Hpack/Run.hs
+++ b/src/Hpack/Run.hs
@@ -30,11 +30,12 @@ import           System.FilePath
 
 import           Hpack.Util
 import           Hpack.Config
+import           Hpack.OptionalExposure
 import           Hpack.Render
 import           Hpack.FormattingHints
 
-run :: FilePath -> IO ([String], FilePath, String)
-run dir = do
+run :: BuildPlan -> FilePath -> IO ([String], FilePath, String)
+run buildPlan dir = do
   mPackage <- readPackageConfig (dir </> packageConfig)
   case mPackage of
     Right (warnings, pkg) -> do
@@ -47,13 +48,13 @@ run dir = do
         alignment = fromMaybe 16 formattingHintsAlignment
         settings = formattingHintsRenderSettings
 
-        output = renderPackage settings alignment formattingHintsFieldOrder formattingHintsSectionsFieldOrder pkg
+        output = renderPackage settings alignment formattingHintsFieldOrder formattingHintsSectionsFieldOrder buildPlan pkg
 
       return (warnings, cabalFile, output)
     Left err -> die err
 
-renderPackage :: RenderSettings -> Alignment -> [String] -> [(String, [String])] -> Package -> String
-renderPackage settings alignment existingFieldOrder sectionsFieldOrder Package{..} = intercalate "\n" (unlines header : chunks)
+renderPackage :: RenderSettings -> Alignment -> [String] -> [(String, [String])] -> BuildPlan -> Package -> String
+renderPackage settings alignment existingFieldOrder sectionsFieldOrder buildPlan Package{..} = intercalate "\n" (unlines header : chunks)
   where
     chunks :: [String]
     chunks = map unlines . filter (not . null) . map (render settings 0) $ sortSectionFields sectionsFieldOrder stanzas
@@ -69,7 +70,7 @@ renderPackage settings alignment existingFieldOrder sectionsFieldOrder Package{.
 
     sourceRepository = maybe [] (return . renderSourceRepository) packageSourceRepository
 
-    library = maybe [] (return . renderLibrary) packageLibrary
+    library = maybe [] (return . renderLibrary buildPlan) packageLibrary
 
     stanzas :: [Element]
     stanzas =
@@ -183,26 +184,28 @@ renderBenchmark sect@(sectionData -> Executable{..}) =
 
 renderExecutableSection :: Section Executable -> [Element]
 renderExecutableSection sect@(sectionData -> Executable{..}) =
-  mainIs : renderSection sect ++ [otherModules, defaultLanguage]
+  mainIs : renderSection [] sect ++ [otherModules, defaultLanguage]
   where
     mainIs = Field "main-is" (Literal executableMain)
     otherModules = renderOtherModules executableOtherModules
 
-renderLibrary :: Section Library -> Element
-renderLibrary sect@(sectionData -> Library{..}) = Stanza "library" $
-  renderSection sect ++
+renderLibrary :: BuildPlan -> Section Library -> Element
+renderLibrary buildPlan sect@(sectionData -> Library{..}) = Stanza "library" $
+  renderSection (concat optDep) sect ++
   maybe [] (return . renderExposed) libraryExposed ++ [
-    renderExposedModules libraryExposedModules
+    renderExposedModules (libraryExposedModules ++ concat optExp)
   , renderOtherModules libraryOtherModules
   , renderReexportedModules libraryReexportedModules
   , defaultLanguage
   ]
+  where (optDep, optExp) =
+          unzip $ map (optionallyExposed buildPlan) libraryOptionallyExposed
 
 renderExposed :: Bool -> Element
 renderExposed = Field "exposed" . Literal . show
 
-renderSection :: Section a -> [Element]
-renderSection Section{..} = [
+renderSection :: [String] -> Section a -> [Element]
+renderSection optionalDeps Section{..} = [
     renderSourceDirs sectionSourceDirs
   , renderDefaultExtensions sectionDefaultExtensions
   , renderOtherExtensions sectionOtherExtensions
@@ -215,7 +218,7 @@ renderSection Section{..} = [
   , Field "extra-lib-dirs" (LineSeparatedList sectionExtraLibDirs)
   , Field "extra-libraries" (LineSeparatedList sectionExtraLibraries)
   , renderLdOptions sectionLdOptions
-  , renderDependencies sectionDependencies
+  , renderDependencies (sectionDependencies ++ map (flip Dependency Nothing) optionalDeps)
   , renderBuildTools sectionBuildTools
   ]
   ++ maybe [] (return . renderBuildable) sectionBuildable
@@ -224,9 +227,9 @@ renderSection Section{..} = [
 renderConditional :: Conditional -> Element
 renderConditional (Conditional condition sect mElse) = case mElse of
   Nothing -> if_
-  Just else_ -> Group if_ (Stanza "else" $ renderSection else_)
+  Just else_ -> Group if_ (Stanza "else" $ renderSection [] else_)
   where
-    if_ = Stanza ("if " ++ condition) (renderSection sect)
+    if_ = Stanza ("if " ++ condition) (renderSection [] sect)
 
 defaultLanguage :: Element
 defaultLanguage = Field "default-language" "Haskell2010"

--- a/src/Hpack/Util.hs
+++ b/src/Hpack/Util.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE CPP, DeriveDataTypeable #-}
 module Hpack.Util (
   List(..)
 , GhcOption
@@ -12,6 +12,7 @@ module Hpack.Util (
 , expandGlobs
 , sort
 , lexicographically
+, hyphenize
 ) where
 
 import           Prelude ()
@@ -118,3 +119,12 @@ expandGlobs dir patterns = do
       , pathSepInRanges = False
       , errorRecovery = True
       }
+
+hyphenize :: String -> String -> String
+hyphenize name =
+#if MIN_VERSION_aeson(0,10,0)
+  camelTo2
+#else
+  camelTo
+#endif
+  '-' . drop (length name) . dropWhile (== '_')

--- a/src/Hpack/VersionRange.hs
+++ b/src/Hpack/VersionRange.hs
@@ -1,0 +1,137 @@
+-- | Definitions and parsing of version numbers and version ranges.
+module Hpack.VersionRange (Version, VersionRange,
+                           parseVersion, parseVersionRange,
+                           -- * Internals
+                           lexVersionRange, parseVersionCmp,
+                           VersionLexeme(..), VersionCmp(..)) where
+import Prelude ()
+import Prelude.Compat
+import Control.Monad ((>=>))
+import Data.Char (isDigit)
+import Data.Version (Version)
+import qualified Data.Version as V
+import Text.ParserCombinators.ReadP (readP_to_S)
+
+uncons :: [a] -> Maybe (a, [a])
+uncons [] = Nothing
+uncons (x:xs) = Just (x,xs)
+
+-- | Read a 'String' of the form @x.y.z@ where @x@, @y@, and @z@ are
+-- integers. There must be at least one integer component, but there
+-- is no limit as to how many there can be.
+parseVersion :: String -> Maybe Version
+parseVersion = aux . map fst . filter (null . snd) . readP_to_S V.parseVersion
+  where aux [x] = Just x
+        aux _ = Nothing
+
+-- | A version range is a predicate on 'Version's
+type VersionRange = Version -> Bool
+
+-- | The AST of a version comparison expression
+data VersionCmp = VEq Version
+                | VLt Version
+                | VGt Version
+                | VAnd VersionCmp VersionCmp
+                | VOr VersionCmp VersionCmp
+                | VAny
+  deriving (Eq, Show)
+
+-- | The lexemes of a version constraint expression
+data VersionLexeme = LexVersion Version
+                   | LexEq
+                   | LexGt
+                   | LexGte
+                   | LexLt
+                   | LexLte
+                   | LexAnd
+                   | LexOr
+                   | LexLParen
+                   | LexRParen
+  deriving (Eq, Show)
+
+-- | Attempt to parse a 'VersionRange' predicate
+parseVersionRange :: String -> Maybe VersionRange
+parseVersionRange =
+  lexVersionRange >=> fmap interpretVersionCmp . parseVersionCmp
+
+-- | Interpret a version comparison syntax tree
+interpretVersionCmp :: VersionCmp -> VersionRange
+interpretVersionCmp VAny _ = True
+interpretVersionCmp (VEq v) v' = v == v'
+interpretVersionCmp (VLt v) v' = v' < v
+interpretVersionCmp (VGt v) v' = v' > v
+interpretVersionCmp (VAnd c c') v =
+  interpretVersionCmp c v && interpretVersionCmp c' v
+interpretVersionCmp (VOr c c') v =
+  interpretVersionCmp c v || interpretVersionCmp c' v
+
+-- | Break an input 'String' into a sequence of lexemes.
+lexVersionRange :: String -> Maybe [VersionLexeme]
+lexVersionRange = (\ws -> if null ws then Just [] else foldMap aux ws) . words
+  where aux tok =
+          case uncons tok of
+            Nothing -> Just []
+            Just (h,t)
+              | isDigit h ->
+                case break (\c -> not (isDigit c || c == '.')) t of
+                  (v, rest) -> parseVersion (h:v) >>=
+                               flip fmap (aux rest) . (:) . LexVersion
+              | h == '>' -> case uncons t of
+                              Just ('=', t') -> (LexGte:) <$> aux t'
+                              _ -> (LexGt :) <$> aux t
+              | h == '<' -> case uncons t of
+                              Just ('=', t') -> (LexLte:) <$> aux t'
+                              _ -> (LexLt :) <$> aux t
+              | h == '=' -> case uncons t of
+                              Just ('=', t') -> (LexEq:) <$> aux t'
+                              _ -> Nothing
+              | h == '&' -> case uncons t of
+                              Just ('&', t') -> (LexAnd:) <$> aux t'
+                              _ -> Nothing
+              | h == '|' -> case uncons t of
+                              Just ('|', t') -> (LexOr:) <$> aux t'
+                              _ -> Nothing
+              | h == '(' -> (LexLParen:) <$> aux t
+              | h == ')' -> (LexRParen:) <$> aux t
+              | otherwise -> Nothing
+
+-- | Break an input stream on the first unbalanced closing
+-- parenthesis. One typically applies this function to an input stream
+-- after encountering an opening parenthesis; the returned tuple is
+-- the parenthetical and the remaining input.
+breakParenthetical :: [VersionLexeme]
+                   -> Maybe ([VersionLexeme], [VersionLexeme])
+breakParenthetical = go id (0::Int)
+  where go acc 0 (LexRParen:ls) = Just (acc [], ls)
+        go acc n (l@LexRParen:ls) = go (acc . (l:)) (n-1) ls
+        go acc n (l@LexLParen:ls) = go (acc . (l:)) (n+1) ls
+        go acc n (l:ls) = go (acc . (l:)) n ls
+        go _ _ [] = Nothing
+
+parseVersionCmp :: [VersionLexeme] -> Maybe VersionCmp
+parseVersionCmp = go []
+  where go [] [] = Just VAny
+        go [s] [] = Just s
+        go stack lexs =
+          case lexs of
+            (LexLParen : ls) -> do (v,ls') <- breakParenthetical ls
+                                   parseVersionCmp v >>= flip go ls' . (:stack)
+            (LexEq : LexVersion v : ls) -> go (VEq v:stack) ls
+            (LexEq : _) -> Nothing
+            (LexLte : LexVersion v : ls) -> go (VOr (VEq v) (VLt v):stack) ls
+            (LexLte : _ ) -> Nothing
+            (LexLt : LexVersion v : ls) -> go (VLt v:stack) ls
+            (LexLt : _) -> Nothing
+            (LexGte : LexVersion v : ls) -> go (VOr (VEq v) (VGt v):stack) ls
+            (LexGte : _) -> Nothing
+            (LexGt : LexVersion v : ls) -> go (VGt v:stack) ls
+            (LexGt : _) -> Nothing
+            (LexAnd : ls) -> case stack of
+                               [l] -> VAnd l <$> parseVersionCmp ls
+                               _ -> Nothing
+            (LexOr : ls) -> case stack of
+                              [l]-> VOr l <$> parseVersionCmp ls
+                              _ -> Nothing
+            (LexVersion _ : _) -> Nothing
+            (LexRParen : _) -> Nothing
+            [] -> Nothing

--- a/test/Hpack/OptionalExposureSpec.hs
+++ b/test/Hpack/OptionalExposureSpec.hs
@@ -1,0 +1,183 @@
+{-# LANGUAGE QuasiQuotes #-}
+module Hpack.OptionalExposureSpec where
+import Data.String.Interpolate
+import Data.Version (showVersion)
+import Helper (withCurrentDirectory, withTempDirectory)
+import Hpack (hpack, version)
+import Hpack.OptionalExposure (BuildPlan(..))
+import System.Directory (createDirectory)
+import System.FilePath ((</>))
+import Test.Hspec
+import Test.Mockery.Directory (touch)
+
+withPackageConfig :: String -> IO () -> Expectation -> Expectation
+withPackageConfig content beforeAction expectation = withTempDirectory $ \dir_ -> do
+  let dir = dir_ </> "NoOrphans"
+  createDirectory dir
+  writeFile (dir </> "package.yaml") content
+  withCurrentDirectory dir (beforeAction >> expectation)
+
+-- | An Hspec package with an optionally exposed module (@Foo.Text@)
+-- ostensibly to provide instances for a data type defined in the
+-- @text@ package.
+package :: String
+package = [i|
+name: NoOrphans
+version: 0.1.0
+synopsis: A demonstration module that provides instances only when needed dependencies are available.
+maintainer: Anthony Cowley <acowley@gmail.com>
+license: BSD3
+category: Development
+ghc-options: -Wall
+dependencies:
+  - base >= 4.7 && < 5
+library:
+  source-dirs: src
+  exposed-modules:
+    - Foo
+  optionally-exposed:
+    dependencies: text > 1.3
+    modules: Foo.Text
+|]
+
+-- | A build plan that does not provide the @text@ package
+buildPlanNoText :: String
+buildPlanNoText = [i|NoOrphans 0.1.0
+array 0.5.1.0
+base 4.8.2.0
+binary 0.7.5.0
+bytestring 0.10.6.0
+containers 0.5.6.2
+deepseq 1.4.1.1
+ghc-prim 0.4.0.0
+integer-gmp 1.0.0.0
+|]
+
+-- | The expected Cabal file resulting from a build plan that does not
+-- provide a suitable version of the @text@ package.
+noTextCabal :: String
+noTextCabal = [i|-- This file has been generated from package.yaml by hpack version #{showVersion version}.
+--
+-- see: https://github.com/sol/hpack
+
+name:           NoOrphans
+version:        0.1.0
+synopsis:       A demonstration module that provides instances only when needed dependencies are available.
+category:       Development
+maintainer:     Anthony Cowley <acowley@gmail.com>
+license:        BSD3
+build-type:     Simple
+cabal-version:  >= 1.10
+
+library
+  hs-source-dirs:
+      src
+  ghc-options: -Wall
+  build-depends:
+      base >= 4.7 && < 5
+  exposed-modules:
+      Foo
+  other-modules:
+      Paths_NoOrphans
+  default-language: Haskell2010
+|]
+
+-- | A build plan with an old version of @text@
+buildPlanOlderText :: String
+buildPlanOlderText = [i|NoOrphans 0.1.0
+array 0.5.1.0
+base 4.8.2.0
+binary 0.7.5.0
+bytestring 0.10.6.0
+containers 0.5.6.2
+deepseq 1.4.1.1
+ghc-prim 0.4.0.0
+integer-gmp 1.0.0.0
+text 1.2.2.1
+|]
+
+-- | A build plan with a new version of @text@ (new in that it
+-- satisfies the constraint identified in 'package').
+buildPlanNewerText :: String
+buildPlanNewerText = [i|NoOrphans 0.1.0
+array 0.5.1.0
+base 4.8.2.0
+binary 0.7.5.0
+bytestring 0.10.6.0
+containers 0.5.6.2
+deepseq 1.4.1.1
+ghc-prim 0.4.0.0
+integer-gmp 1.0.0.0
+text 1.4
+|]
+
+-- | The expected Cabal file resulting from a build plan that provides
+-- a suitable version of the @text@ package.
+newerTextCabal :: String
+newerTextCabal = [i|-- This file has been generated from package.yaml by hpack version #{showVersion version}.
+--
+-- see: https://github.com/sol/hpack
+
+name:           NoOrphans
+version:        0.1.0
+synopsis:       A demonstration module that provides instances only when needed dependencies are available.
+category:       Development
+maintainer:     Anthony Cowley <acowley@gmail.com>
+license:        BSD3
+build-type:     Simple
+cabal-version:  >= 1.10
+
+library
+  hs-source-dirs:
+      src
+  ghc-options: -Wall
+  build-depends:
+      base >= 4.7 && < 5
+    , text > 1.3
+  exposed-modules:
+      Foo
+      Foo.Text
+  other-modules:
+      Paths_NoOrphans
+  default-language: Haskell2010
+|]
+
+prepSourceTree :: IO ()
+prepSourceTree =
+  do touch "src/Foo.hs"
+     touch "src/Foo/Text.hs"
+     writeFile "buildPlanNoText" buildPlanNoText
+     writeFile "buildPlanOlderText" buildPlanOlderText
+     writeFile "buildPlanNewerText" buildPlanNewerText
+
+spec :: Spec
+spec = do it "Exports optional modules when no build plan is given" $ do
+            withPackageConfig
+              package
+              (do prepSourceTree
+                  hpack (Left MaximalBuildPlan) "." False)
+              (readFile "NoOrphans.cabal" `shouldReturn` newerTextCabal)
+          it "Hides when a minimal build plan is specified" $
+            withPackageConfig
+              package
+              (do prepSourceTree
+                  hpack (Left MinimalBuildPlan) "." False)
+              (readFile "NoOrphans.cabal" `shouldReturn` noTextCabal)
+          it "Exports modules when constraints are satisfied" $ do
+            withPackageConfig
+              package
+              (do prepSourceTree
+                  hpack (Right "buildPlanNewerText") "." False)
+              (readFile "NoOrphans.cabal" `shouldReturn` newerTextCabal)
+          it "Hides when constraints are not satisfied" $ do
+            withPackageConfig
+              package
+              (do prepSourceTree
+                  hpack (Right "buildPlanOlderText") "." False)
+              (readFile "NoOrphans.cabal" `shouldReturn` noTextCabal)
+          it "Hides when dependencies are not available" $ do
+            withPackageConfig
+              package
+              (do prepSourceTree
+                  hpack (Right "buildPlanNoText") "." False)
+              (readFile "NoOrphans.cabal" `shouldReturn` noTextCabal)

--- a/test/Hpack/RunSpec.hs
+++ b/test/Hpack/RunSpec.hs
@@ -6,13 +6,17 @@ import           Data.List.Compat
 
 import           Hpack.ConfigSpec hiding (spec)
 import           Hpack.Config hiding (package)
+import           Hpack.OptionalExposure (BuildPlan(MaximalBuildPlan))
 import           Hpack.Render
 import           Hpack.Run
+
+maxBuild :: BuildPlan
+maxBuild = MaximalBuildPlan
 
 spec :: Spec
 spec = do
   describe "renderPackage" $ do
-    let renderPackage_ = renderPackage defaultRenderSettings 0 [] []
+    let renderPackage_ = renderPackage defaultRenderSettings 0 [] [] maxBuild
     it "renders a package" $ do
       renderPackage_ package `shouldBe` unlines [
           "name: foo"
@@ -22,7 +26,7 @@ spec = do
         ]
 
     it "aligns fields" $ do
-      renderPackage defaultRenderSettings 16 [] [] package `shouldBe` unlines [
+      renderPackage defaultRenderSettings 16 [] [] maxBuild package `shouldBe` unlines [
           "name:           foo"
         , "version:        0.0.0"
         , "build-type:     Simple"
@@ -41,7 +45,7 @@ spec = do
         ]
 
     it "aligns description" $ do
-      renderPackage defaultRenderSettings 16 [] [] package {packageDescription = Just "foo\n\nbar\n"} `shouldBe` unlines [
+      renderPackage defaultRenderSettings 16 [] [] maxBuild package {packageDescription = Just "foo\n\nbar\n"} `shouldBe` unlines [
           "name:           foo"
         , "version:        0.0.0"
         , "description:    foo"
@@ -70,7 +74,7 @@ spec = do
         ]
 
     it "aligns copyright holders" $ do
-      renderPackage defaultRenderSettings 16 [] [] package {packageCopyright = ["(c) 2015 Foo", "(c) 2015 Bar"]} `shouldBe` unlines [
+      renderPackage defaultRenderSettings 16 [] [] maxBuild package {packageCopyright = ["(c) 2015 Foo", "(c) 2015 Bar"]} `shouldBe` unlines [
           "name:           foo"
         , "version:        0.0.0"
         , "copyright:      (c) 2015 Foo,"
@@ -156,7 +160,7 @@ spec = do
 
     context "when given list of existing fields" $ do
       it "retains field order" $ do
-        renderPackage defaultRenderSettings 16 ["cabal-version", "version", "name", "build-type"] [] package `shouldBe` unlines [
+        renderPackage defaultRenderSettings 16 ["cabal-version", "version", "name", "build-type"] [] maxBuild package `shouldBe` unlines [
             "cabal-version:  >= 1.10"
           , "version:        0.0.0"
           , "name:           foo"
@@ -164,7 +168,7 @@ spec = do
           ]
 
       it "uses default field order for new fields" $ do
-        renderPackage defaultRenderSettings 16 ["name", "version", "cabal-version"] [] package `shouldBe` unlines [
+        renderPackage defaultRenderSettings 16 ["name", "version", "cabal-version"] [] maxBuild package `shouldBe` unlines [
             "name:           foo"
           , "version:        0.0.0"
           , "build-type:     Simple"
@@ -172,7 +176,7 @@ spec = do
           ]
 
       it "retains section field order" $ do
-        renderPackage defaultRenderSettings 0 [] [("executable foo", ["default-language", "main-is", "ghc-options"])] package {packageExecutables = [(section $ executable "foo" "Main.hs") {sectionGhcOptions = ["-Wall", "-Werror"]}]} `shouldBe` unlines [
+        renderPackage defaultRenderSettings 0 [] [("executable foo", ["default-language", "main-is", "ghc-options"])] maxBuild package {packageExecutables = [(section $ executable "foo" "Main.hs") {sectionGhcOptions = ["-Wall", "-Werror"]}]} `shouldBe` unlines [
             "name: foo"
           , "version: 0.0.0"
           , "build-type: Simple"

--- a/test/Hpack/VersionRangeSpec.hs
+++ b/test/Hpack/VersionRangeSpec.hs
@@ -1,0 +1,101 @@
+module Hpack.VersionRangeSpec where
+import Prelude ()
+import Prelude.Compat
+import Data.Maybe (isNothing, isJust, fromMaybe)
+import Data.Version (showVersion)
+import Hpack.VersionRange
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "parseVersion" $ do
+    context "when version is empty" $
+      it "returns Nothing" $ parseVersion "" `shouldBe` Nothing
+    context "when version is invalid" $ do
+      it "rejects double  dots" $
+        parseVersion "1..2.3" `shouldBe` Nothing
+      it "rejects invalid characters" $
+        parseVersion "1.a" `shouldBe` Nothing
+      it "rejects negative versions" $
+        parseVersion "-2" `shouldBe` Nothing
+    context "when version is valid" $ do
+      it "accepts a single integer" $
+        showVersion <$> (parseVersion "42") `shouldBe` Just "42"
+      it "accepts multi-component versions" $
+        showVersion <$> (parseVersion "3.14") `shouldBe` Just "3.14"
+      it "accepts 3.9.0" $
+        showVersion <$> (parseVersion "3.9.0") `shouldBe` Just "3.9.0"
+  describe "Version ordering" $ do
+    it "Orders on major version (1)" $
+      parseVersion "2.1" > parseVersion "1.5"
+    it "Orders on major version (2)" $
+      parseVersion "2.2" < parseVersion "2.4"
+    it "Can compare versions of differing lengths" $
+      parseVersion "2.3" > parseVersion "2.2.5"
+  describe "parseVersionRange" $ do
+    it "Rejects invalid ranges: ><" $
+      isNothing (parseVersionRange ">< 2")
+    it "Rejects invalid ranges: 3 <" $
+      isNothing (parseVersionRange "3 <")
+    it "Rejects invalid ranges: 3 < 4" $
+      isNothing (parseVersionRange "3 < 4")
+    it "Rejects unbalanced opening parentheses" $
+      isNothing (parseVersionRange "(< 5.2")
+    it "Rejects unbalanced closing parentheses" $
+      isNothing (parseVersionRange "< 5.2)")
+    let pv x = fromMaybe (error $ "Assumed we could parse "++x)
+                         (parseVersion x)
+        lexedDisjunction = lexVersionRange "< 2 || > 5.2"
+        lexedConjunction = lexVersionRange "(> 3 && < 4) || (> 6 && < 6.2)"
+    context "Lexing" $ do
+      it "Lexes disjunction" $
+        lexedDisjunction `shouldBe`
+          Just [LexLt, LexVersion (pv "2"), LexOr, LexGt, LexVersion (pv "5.2")]
+      it "Lexes conjunction" $
+         lexedConjunction `shouldBe`
+           Just [ LexLParen, LexGt, LexVersion (pv "3"), LexAnd, LexLt
+                , LexVersion (pv "4"), LexRParen, LexOr, LexLParen, LexGt
+                , LexVersion (pv "6"), LexAnd, LexLt, LexVersion (pv "6.2")
+                , LexRParen ]
+    context "Parsing" $ do
+      it "Parses disjunction" $
+        (lexedDisjunction >>= parseVersionCmp) `shouldBe`
+          Just (VOr (VLt (pv "2")) (VGt (pv "5.2")))
+      it "Parses conjunction" $
+        (lexedConjunction >>= parseVersionCmp) `shouldBe`
+          Just (VOr (VAnd (VGt (pv "3")) (VLt (pv "4")))
+                    (VAnd (VGt (pv "6")) (VLt (pv "6.2"))))
+    context "Less than constraint" $ do
+      let Just v = parseVersionRange "< 2"
+      it "Accepts less than" $ (v <$> parseVersion "1.9") `shouldBe` Just True
+      it "Rejects equal" $ (v <$> parseVersion "2") `shouldBe` Just False
+      it "Rejects greater" $ (v <$> parseVersion "2.1") `shouldBe` Just False
+    context "Less-than-or-equal" $ do
+      let Just v = parseVersionRange "<= 2.1"
+      it "Accepts less than" $ (v <$> parseVersion "2") `shouldBe` Just True
+      it "Accepts equal" $ (v <$> parseVersion "2.1") `shouldBe` Just True
+      it "Rejects greater" $ (v <$> parseVersion "2.1.1") `shouldBe` Just False
+    context "Disjunction of ranges" $ do
+      let v'@(~(Just v)) = parseVersionRange "< 2 || > 5.2"
+      it "Parses disjunctions" $ isJust v'
+      it "Accepts left disjunct" $
+        v <$> parseVersion "1.5" `shouldBe` Just True
+      it "Accepts right disjunct" $
+        v <$> parseVersion "5.2.1" `shouldBe` Just True
+      it "Rejects appropriately" $
+        (v <$> parseVersion "3") `shouldBe` Just False
+    context "Conjunction of ranges" $ do
+      let v'@ (~ (Just v)) = parseVersionRange "> 3 && < 4"
+      it "Parses conjunction" $ isJust v'
+      it "Accepts appropriately" $
+        v <$> parseVersion "3.9.0" `shouldBe` Just True
+      it "Rejects appropriately" $
+        v <$> parseVersion "4.0.1" `shouldBe` Just False
+    context "Conjunction of disjunctions" $ do
+      let v'@(~(Just v)) = parseVersionRange "(> 3 && < 4) || (> 6 && < 6.2)"
+      it "Parses" (isJust v')
+      it "Rejects" (v <$> parseVersion "5" `shouldBe` Just False)
+      it "Accepts on the left" $
+        (v <$> parseVersion "3.9.0") `shouldBe` Just True
+      it "Accepts on the right" $
+        (v <$> parseVersion "6.0.1") `shouldBe` Just True

--- a/test/HpackSpec.hs
+++ b/test/HpackSpec.hs
@@ -12,20 +12,32 @@ import           Test.Mockery.Directory
 import           Test.QuickCheck
 
 import           Hpack
+import           Hpack.OptionalExposure (BuildPlan(..))
 
 makeVersion :: [Int] -> Version
 makeVersion v = Version v []
+
+maxBuild :: Either BuildPlan a
+maxBuild = Left MaximalBuildPlan
 
 spec :: Spec
 spec = do
   describe "parseVerbosity" $ do
     it "returns True by default" $ do
       parseVerbosity ["foo"] `shouldBe` (True, ["foo"])
-
     context "with --silent" $ do
       it "returns False" $ do
         parseVerbosity ["--silent"] `shouldBe` (False, [])
 
+  describe "parseBuildplan" $ do
+    it "returns MaximalBuildPlan by default" $ do
+      parseBuildplan ["foo","bar"] `shouldBe` (Left MaximalBuildPlan, ["foo","bar"])
+    it "accepts \"min\" as a build plan" $ do
+      parseBuildplan ["foo", "--buildplan", "min", "bar"]
+        `shouldBe` (Left MinimalBuildPlan, ["foo", "bar"])
+    it "returns the build plan file when available" $ do
+      parseBuildplan ["foo", "--buildplan", "baz", "bar"]
+        `shouldBe` (Right "baz", ["foo", "bar"])
   describe "extractVersion" $ do
     it "extracts Hpack version from a cabal file" $ do
       let cabalFile = ["-- This file has been generated from package.yaml by hpack version 0.10.0."]
@@ -47,9 +59,9 @@ spec = do
       it "does not write a new cabal file" $ do
         inTempDirectory $ do
           writeFile "package.yaml" "name: foo"
-          hpackWithVersion (makeVersion [0,8,0]) "." False
+          hpackWithVersion (makeVersion [0,8,0]) maxBuild "." False
           old <- readFile "foo.cabal" >>= (return $!!)
-          hpackWithVersion (makeVersion [0,10,0]) "." False
+          hpackWithVersion (makeVersion [0,10,0]) maxBuild "." False
           readFile "foo.cabal" `shouldReturn` old
 
     context "when exsting cabal file was generated with a newer version of hpack" $ do
@@ -59,7 +71,7 @@ spec = do
               "name: foo"
             , "version: 0.1.0"
             ]
-          hpackWithVersion (makeVersion [0,10,0]) "." False
+          hpackWithVersion (makeVersion [0,10,0]) maxBuild "." False
           old <- readFile "foo.cabal" >>= (return $!!)
 
           writeFile "package.yaml" $ unlines [
@@ -67,5 +79,5 @@ spec = do
             , "version: 0.2.0"
             ]
 
-          hpackWithVersion (makeVersion [0,8,0]) "." False
+          hpackWithVersion (makeVersion [0,8,0]) maxBuild "." False
           readFile "foo.cabal" `shouldReturn` old


### PR DESCRIPTION
This is a mechanism to eliminate the appeal of defining orphan instances
in Haskell packages.

The problem: If I define a new type class for which instances may be
defined for types defined in other packages, I must either depend on
those packages or ask that those packages' authors depend on my
package.

The solution: Allow a library author to identify individual modules that
should only be built if a necessary dependency is included in a build in
which the library is involved.

Details:

A new `optionally-exposed` section of a library stanza supports the
specification of potentially exposed modules and their dependencies. The
inclusion of these modules and dependencies in the generated Cabal file
depends upon the availability of a build plan.

A build plan in this context is simply a list of package names and
versions as output by, for example, `stack list-dependencies`.

If no build plan is supplied, then all "optionally-exposed" modules are
exposed, and their dependencies must be available.

If a build plan is supplied, then only those "optionally-exposed"
modules whose dependencies are satisfied by the build plan are included
in the Cabal file generated for the package.

Usage by build tools:

A tool like stack can invoke `hpack --buildplan min` for each listed
dependency when computing an initial build plan. Then it can call
`hpack` for each package again, this time passing the name of a file
containing the computed build plan. This second round will not add any
new packages to the build plan, but may add dependencies to the
individual packages included in the build plan.

Usage by library authors:

If you wish to provide an instance for, say, `Data.Text.Text`, but do
not otherwise use the `text` package, place the instance definition in
its own module, say, `src/Foo/Text.hs`. Then add an
`optionally-exposed` section to the `library` definition so it looks
something like this,

```
library:
  source-dirs: src
  optionally-exposed:
    dependencies: text > 1.2
    modules: Foo.Text
```

Now, if somebody uses your library without themselves depending on
`text`, they may do so without incurring a dependency on `text`. If they
do depend on `text`, then they will have access to the instance you
defined.
