### PR TITLE
Add conversion from cabal files

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -11,6 +11,8 @@ ghc-options: -Wall
 dependencies:
   - base >= 4.7 && < 5
   - base-compat >= 0.8
+  - Cabal
+  - pretty
   - deepseq
   - directory
   - filepath
@@ -19,6 +21,8 @@ dependencies:
   - containers
   - unordered-containers
   - yaml
+  - bytestring
+  - vector
 
 library:
   source-dirs: src

--- a/src/Hpack.hs
+++ b/src/Hpack.hs
@@ -32,6 +32,7 @@ import           Text.ParserCombinators.ReadP
 
 import           Paths_hpack (version)
 import           Hpack.Config
+import           Hpack.Convert.Run
 import           Hpack.Run
 
 programVersion :: Version -> String
@@ -50,6 +51,7 @@ main = do
   args <- getArgs
   case args of
     ["--version"] -> putStrLn (programVersion version)
+    ("--convert":_) -> runConvert
     ["--help"] -> printHelp
     _ -> case parseVerbosity args of
       (verbose, [dir]) -> hpack dir verbose
@@ -62,6 +64,7 @@ printHelp :: IO ()
 printHelp = do
   hPutStrLn stderr $ unlines [
       "Usage: hpack [ --silent ] [ dir ]"
+    , "       hpack --convert [ dir | cabalfile ]"
     , "       hpack --version"
     ]
 

--- a/src/Hpack/Convert.hs
+++ b/src/Hpack/Convert.hs
@@ -1,0 +1,264 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+module Hpack.Convert where
+
+import           Control.Applicative
+import           Data.Maybe
+import qualified Data.Version as Version
+import qualified Distribution.Compiler as Compiler
+import qualified Distribution.InstalledPackageInfo as Cabal
+import qualified Distribution.Package as Cabal
+import qualified Distribution.PackageDescription as Cabal
+import qualified Distribution.PackageDescription.Parse as Cabal
+import qualified Distribution.Text as Cabal
+import qualified Distribution.Version as Cabal
+import           Hpack.Config  hiding (package)
+import           Text.PrettyPrint (fsep, (<+>))
+
+-- * Public API
+
+-- | Reads a 'Package' from cabal's 'GenericPackageDescription' representation
+-- of a @.cabal@ file
+fromPackageDescription :: Cabal.GenericPackageDescription -> Package
+fromPackageDescription Cabal.GenericPackageDescription{..} =
+    let Cabal.PackageDescription{..} = packageDescription
+    in
+    Package { packageName = Cabal.unPackageName (Cabal.pkgName package)
+            , packageVersion = Version.showVersion (Cabal.pkgVersion package)
+            , packageSynopsis = nullNothing synopsis
+            , packageDescription = nullNothing description
+            , packageHomepage = nullNothing homepage
+            , packageBugReports = nullNothing bugReports
+            , packageCategory = nullNothing category
+            , packageStability = nullNothing stability
+            , packageAuthor = maybeToList (nullNothing author)
+            , packageMaintainer = maybeToList (nullNothing maintainer)
+            , packageCopyright = maybeToList (nullNothing copyright)
+            , packageLicense = Just (show (Cabal.disp license))
+            , packageLicenseFile = listToMaybe licenseFiles
+            , packageTestedWith =
+                    show .
+                    fsep . map (\(f, vr) -> Cabal.disp f <+> Cabal.disp vr ) <$>
+                    nullNothing testedWith
+            , packageFlags =
+                    map (\Cabal.MkFlag{..} ->
+                             let Cabal.FlagName fn = flagName
+                             in Flag { flagName = fn
+                                     , flagDescription =
+                                             nullNothing flagDescription
+                                     , flagManual = flagManual
+                                     , flagDefault = flagDefault
+                                     })
+                    genPackageFlags
+            , packageExtraSourceFiles = extraSrcFiles
+            , packageDataFiles = dataFiles
+            , packageSourceRepository = fromSourceRepos sourceRepos
+            , packageLibrary = fromCondLibrary condLibrary
+            , packageExecutables = fromCondExecutables condExecutables
+            , packageTests = fromCondTestSuites condTestSuites
+            , packageBenchmarks = fromCondBenchmarks condBenchmarks
+            }
+
+-- | Reads a 'Package' from a @.cabal@ manifest string
+fromPackageDescriptionString :: String -> Either ConvertError Package
+fromPackageDescriptionString pkgStr =
+    case Cabal.parsePackageDescription pkgStr of
+        Cabal.ParseFailed e -> Left (ConvertCabalParseError e)
+        Cabal.ParseOk _ gpkg -> Right (fromPackageDescription gpkg)
+
+data ConvertError = ConvertCabalParseError Cabal.PError
+  deriving(Show, Eq)
+
+-- data ConvertWarning = CWIgnoreSection String
+--                     | CWIgnoreCondition String
+--                     | CWIgnoreSourceRepo Cabal.SourceRepo
+--                     | CWSourceRepoWithoutUrl Cabal.SourceRepo
+
+-- * Private functions for converting each section
+
+fromSourceRepos :: [Cabal.SourceRepo] -> Maybe SourceRepository
+fromSourceRepos [] = Nothing
+fromSourceRepos (_repo@Cabal.SourceRepo{..}:_more) =
+    -- (
+    Just SourceRepository { sourceRepositoryUrl = fromMaybe "" repoLocation
+                          -- TODO - this is broken (?)
+                          , sourceRepositorySubdir = repoSubdir
+                          }
+    -- TODO - Warnings
+    -- , case repoLocation of
+    --       Nothing -> [CWSourceRepoWithoutUrl repo]
+    --       _ -> []
+    --   ++ map CWIgnoreSourceRepo more
+    -- )
+
+fromDependency :: Cabal.Dependency -> Dependency
+fromDependency (Cabal.Dependency pn Cabal.AnyVersion) =
+    Dependency (show (Cabal.disp pn)) Nothing
+fromDependency (Cabal.Dependency pn vr) =
+    Dependency (show (Cabal.disp pn <+> Cabal.disp vr)) Nothing
+
+fromCondLibrary :: Maybe (Cabal.CondTree Cabal.ConfVar [Cabal.Dependency] Cabal.Library) -> Maybe (Section Library)
+fromCondLibrary mcondLibrary = do
+    condLibrary@(Cabal.CondNode Cabal.Library{libBuildInfo} _ components) <- mcondLibrary
+    l <- libFromCondLibrary condLibrary
+    return (sectionWithBuildInfo l libBuildInfo)
+        { sectionConditionals = map fromCondComponentHasBuildInfo components
+        }
+
+fromCondExecutables :: [(String, Cabal.CondTree Cabal.ConfVar [Cabal.Dependency] Cabal.Executable)] -> [Section Executable]
+fromCondExecutables = map fromCondExecutableTup
+
+fromCondTestSuites :: [(String, Cabal.CondTree Cabal.ConfVar [Cabal.Dependency] Cabal.TestSuite)] -> [Section Executable]
+fromCondTestSuites = mapMaybe fromCondTestSuiteTup
+
+fromCondBenchmarks :: [(String, Cabal.CondTree Cabal.ConfVar [Cabal.Dependency] Cabal.Benchmark)] -> [Section Executable]
+fromCondBenchmarks = mapMaybe fromCondBenchmarkTup
+
+fromCondExecutableTup :: (String, Cabal.CondTree Cabal.ConfVar [Cabal.Dependency] Cabal.Executable) -> Section Executable
+fromCondExecutableTup etup@(_, Cabal.CondNode Cabal.Executable{buildInfo} _ components) =
+    let e = exeFromCondExecutableTup etup
+    in (sectionWithBuildInfo e buildInfo)
+       { sectionConditionals = map fromCondComponentHasBuildInfo components
+       }
+
+fromCondTestSuiteTup :: (String, Cabal.CondTree Cabal.ConfVar [Cabal.Dependency] Cabal.TestSuite) -> Maybe (Section Executable)
+fromCondTestSuiteTup ttup@(_, Cabal.CondNode Cabal.TestSuite{testBuildInfo} _ components) = do
+    te <- testExeFromCondExecutableTup ttup
+    return (sectionWithBuildInfo te testBuildInfo)
+       { sectionConditionals = map fromCondComponentHasBuildInfo components
+       }
+
+fromCondBenchmarkTup :: (String, Cabal.CondTree Cabal.ConfVar [Cabal.Dependency] Cabal.Benchmark) -> Maybe (Section Executable)
+fromCondBenchmarkTup btup@(_, Cabal.CondNode Cabal.Benchmark{benchmarkBuildInfo} _ components) = do
+    be <- benchExeFromCondExecutableTup btup
+    return (sectionWithBuildInfo be benchmarkBuildInfo)
+       { sectionConditionals = map fromCondComponentHasBuildInfo components
+       }
+
+-- * Conditional Mapping
+class HasBuildInfo a where
+    getBuildInfo :: a -> Cabal.BuildInfo
+
+instance HasBuildInfo Cabal.Library where
+    getBuildInfo Cabal.Library{libBuildInfo} = libBuildInfo
+
+instance HasBuildInfo Cabal.Executable where
+    getBuildInfo Cabal.Executable{buildInfo} = buildInfo
+
+instance HasBuildInfo Cabal.TestSuite where
+    getBuildInfo Cabal.TestSuite{testBuildInfo} = testBuildInfo
+
+instance HasBuildInfo Cabal.Benchmark where
+    getBuildInfo Cabal.Benchmark{benchmarkBuildInfo} = benchmarkBuildInfo
+
+fromCondHasBuildInfo :: HasBuildInfo a => Cabal.CondTree Cabal.ConfVar [Cabal.Dependency] a -> Section ()
+fromCondHasBuildInfo (Cabal.CondNode hbi _ components) =
+    let bi = getBuildInfo hbi
+    in (sectionWithBuildInfo () bi)
+       { sectionConditionals = map fromCondComponentHasBuildInfo components
+       }
+
+fromCondComponentHasBuildInfo :: (HasBuildInfo a)
+    => ( Cabal.Condition Cabal.ConfVar
+       , Cabal.CondTree Cabal.ConfVar [Cabal.Dependency] a
+       , Maybe (Cabal.CondTree Cabal.ConfVar [Cabal.Dependency] a)
+       )
+    -> Conditional
+fromCondComponentHasBuildInfo (cond, ifTree, elseTree) =
+    Conditional { conditionalCondition = fromCondition cond
+                , conditionalThen = fromCondHasBuildInfo ifTree
+                , conditionalElse = fromCondHasBuildInfo <$> elseTree
+                }
+
+fromCondition :: Cabal.Condition Cabal.ConfVar -> String
+fromCondition (Cabal.Var c) = case c of
+    Cabal.OS os -> "os(" ++ show (Cabal.disp os) ++ ")"
+    Cabal.Flag (Cabal.FlagName fl) -> "flag(" ++ fl ++ ")"
+    Cabal.Arch ar -> "arch(" ++ show (Cabal.disp ar) ++ ")"
+    Cabal.Impl cc vr -> "impl(" ++ show (Cabal.disp cc <+> Cabal.disp vr)  ++ ")"
+fromCondition (Cabal.CNot c) = "!(" ++ fromCondition c ++ ")"
+fromCondition (Cabal.COr c1 c2) = "(" ++ fromCondition c1 ++ ") || (" ++ fromCondition c2 ++ ")"
+fromCondition (Cabal.CAnd c1 c2) = "(" ++ fromCondition c1 ++ ") && (" ++ fromCondition c2 ++ ")"
+fromCondition (Cabal.Lit b) = show b
+
+
+-- * Private helpers
+
+-- | Builds a 'Package' 'Section' from a data entity and a 'BuildInfo' entity
+sectionWithBuildInfo :: a -> Cabal.BuildInfo -> Section a
+sectionWithBuildInfo d Cabal.BuildInfo{..} =
+    Section { sectionData = d
+            , sectionSourceDirs = hsSourceDirs
+            , sectionDependencies = map fromDependency targetBuildDepends
+            , sectionDefaultExtensions = map (show . Cabal.disp)
+                                             defaultExtensions
+            , sectionOtherExtensions = map (show . Cabal.disp) otherExtensions
+            , sectionGhcOptions = fromMaybe [] $
+                lookup Compiler.GHC options
+            , sectionGhcProfOptions = fromMaybe [] $
+                lookup Compiler.GHC profOptions
+            , sectionCppOptions = cppOptions
+            , sectionCCOptions = ccOptions
+            , sectionCSources = cSources
+            , sectionExtraLibDirs = extraLibDirs
+            , sectionExtraLibraries = extraLibs
+            , sectionIncludeDirs = includeDirs
+            , sectionInstallIncludes = installIncludes
+            , sectionLdOptions = ldOptions
+            , sectionBuildable = Just buildable
+            -- TODO ^^ ????
+            , sectionConditionals = []
+            -- TODO ^^ ????
+            , sectionBuildTools = map fromDependency buildTools
+            }
+
+libFromCondLibrary :: Cabal.CondTree Cabal.ConfVar [Cabal.Dependency] Cabal.Library -> Maybe Library
+libFromCondLibrary (Cabal.CondNode (Cabal.Library{..}) _ _) = do
+    let Cabal.BuildInfo{..} = libBuildInfo
+    return Library { libraryExposed = Just libExposed
+                   , libraryExposedModules = map (show . Cabal.disp)
+                                                 exposedModules
+                   , libraryOtherModules = map (show . Cabal.disp) otherModules
+                   , libraryReexportedModules = map (show . Cabal.disp)
+                                                    reexportedModules
+                   }
+
+exeFromCondExecutableTup :: (String, Cabal.CondTree Cabal.ConfVar [Cabal.Dependency] Cabal.Executable) -> Executable
+exeFromCondExecutableTup (name, Cabal.CondNode Cabal.Executable{..} _ _) =
+    Executable { executableName = name
+               , executableMain = modulePath
+               , executableOtherModules = map (show . Cabal.disp)
+                                              (Cabal.otherModules buildInfo)
+               }
+
+testExeFromCondExecutableTup :: (String, Cabal.CondTree Cabal.ConfVar [Cabal.Dependency] Cabal.TestSuite) -> Maybe Executable
+testExeFromCondExecutableTup (name, Cabal.CondNode Cabal.TestSuite{..} _ _) =
+    case testInterface of
+        Cabal.TestSuiteExeV10 _ mainIs -> Just
+            Executable { executableName = name
+                       , executableMain = mainIs
+                       , executableOtherModules = map (show . Cabal.disp)
+                                                  (Cabal.otherModules testBuildInfo)
+                       }
+        _ -> Nothing
+
+benchExeFromCondExecutableTup :: (String, Cabal.CondTree Cabal.ConfVar [Cabal.Dependency] Cabal.Benchmark) -> Maybe Executable
+benchExeFromCondExecutableTup (name, Cabal.CondNode Cabal.Benchmark{..} _ _) =
+    case benchmarkInterface of
+        Cabal.BenchmarkExeV10 _ mainIs -> Just
+            Executable { executableName = name
+                       , executableMain = mainIs
+                       , executableOtherModules = map (show . Cabal.disp)
+                                                  (Cabal.otherModules benchmarkBuildInfo)
+                       }
+        _ -> Nothing
+
+-- | Returns Nothing if a list is empty and Just the list otherwise
+--
+-- >>> nullNothing []
+-- Nothing
+-- >>> nullNothing [1, 2, 3]
+-- Just [1, 2, 3]
+nullNothing :: [a] -> Maybe [a]
+nullNothing s = const s <$> listToMaybe s

--- a/src/Hpack/Convert/Run.hs
+++ b/src/Hpack/Convert/Run.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE TupleSections #-}
+module Hpack.Convert.Run
+    ( runConvert
+    )
+  where
+
+import           Control.Applicative
+import           Control.Monad
+import           Data.List
+import           Data.Maybe
+import           System.Directory
+import           System.Environment
+import           System.Exit
+import           System.FilePath
+import           System.FilePath.Glob
+
+import           Hpack.Config
+import           Hpack.Convert
+
+runConvert :: IO ()
+runConvert = do
+    as <- getArgs
+    (dir, cabalFileFP) <- case as of
+        ("--convert":dir:_) -> do
+            isFile <- doesFileExist dir
+            if takeExtension dir == ".cabal" && isFile
+                then return (takeDirectory dir, dir)
+                else (dir,) <$> findCabalFileFP dir
+        ["--convert"] -> do
+            cwd <- getCurrentDirectory
+            cabalFileFP <- findCabalFileFP cwd
+            return (cwd, cabalFileFP)
+        _ -> die "Usage: hpack --convert [ dir | cabal file ]"
+    pkg <- runConvert' dir cabalFileFP
+    writePackage (dir </> "package.yaml") pkg
+    putStrLn $ "generated package.yaml based on " ++ cabalFileFP
+
+findCabalFileFP :: FilePath -> IO FilePath
+findCabalFileFP dir = do
+    mcabalFileFP <- listToMaybe <$> globDir1 (compile "*.cabal") dir
+    case mcabalFileFP of
+        Nothing -> die "No cabal file in the current directory"
+        Just cabalFileFP -> return cabalFileFP
+
+runConvert' :: FilePath -> FilePath -> IO Package
+runConvert' dir cabalFileFP = do
+    mpackageYaml <- find (== "package.yaml") <$> getDirectoryContents dir
+
+    when (isJust mpackageYaml) $
+        die $ (dir </> "package.yaml") ++ " already exists"
+
+    old <- readFile cabalFileFP
+    case fromPackageDescriptionString old of
+        Left err -> die (show err)
+        Right pkg -> return pkg

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,4 +3,5 @@ packages:
 - '.'
 extra-deps:
 - aeson-0.11.0.0
+- unordered-containers-0.2.7.1
 resolver: lts-5.3

--- a/test/Hpack/ConfigSpec.hs
+++ b/test/Hpack/ConfigSpec.hs
@@ -999,3 +999,54 @@ spec = do
         it "returns an error" $ \dir -> do
           let file = dir </> "package.yaml"
           readPackageConfig file `shouldReturn` Left [i|#{file}: Yaml file not found: #{file}|]
+
+  context "toJSON :: Conditinal -> Value" $ do
+    it "serializes conditionals properly" $ do
+      let s = emptySection { sectionBuildable = Just False }
+      toJSON (Conditional "os(darwin)" s Nothing)
+        `shouldBe` object [ "condition" .= String "os(darwin)"
+                          , "buildable" .= Bool False
+                          ]
+
+    it "serializes conditionals with an else branch properly" $ do
+      let s = emptySection { sectionBuildable = Just False }
+      toJSON (Conditional "os(darwin)" s (Just s))
+        `shouldBe` object [ "condition" .= String "os(darwin)"
+                          , "then" .= object [ "buildable" .= Bool False
+                                             ]
+                          , "else" .= object [ "buildable" .= Bool False
+                                             ]
+                          ]
+
+
+  context "toJSON :: Section a -> Value" $
+    it "serializes conditionals properly" $ do
+      let s = emptySection { sectionConditionals = [ Conditional "os(darwin)" emptySection { sectionBuildable = Just False } Nothing]
+                           }
+      toJSON s
+        `shouldBe` object [ "when" .= array [ object [ "condition" .= String "os(darwin)"
+                                                     , "buildable" .= Bool False
+                                                     ]
+                                            ]
+                          ]
+
+emptySection :: Section ()
+emptySection = Section { sectionData = ()
+                       , sectionSourceDirs = []
+                       , sectionDependencies = []
+                       , sectionDefaultExtensions = []
+                       , sectionOtherExtensions = []
+                       , sectionGhcOptions = []
+                       , sectionGhcProfOptions = []
+                       , sectionCppOptions = []
+                       , sectionCCOptions = []
+                       , sectionCSources = []
+                       , sectionExtraLibDirs = []
+                       , sectionExtraLibraries = []
+                       , sectionIncludeDirs = []
+                       , sectionInstallIncludes = []
+                       , sectionLdOptions = []
+                       , sectionBuildable = Nothing
+                       , sectionConditionals = []
+                       , sectionBuildTools = []
+                       }

--- a/test/Hpack/ConvertSpec.hs
+++ b/test/Hpack/ConvertSpec.hs
@@ -5,7 +5,8 @@ import           Prelude ()
 import           Prelude.Compat
 
 import           Control.Monad
-import qualified Data.ByteString as ByteString
+import qualified Data.ByteString as ByteString hiding (pack, unpack)
+import qualified Data.ByteString.Char8 as ByteString (unpack)
 import           System.Directory
 import           System.FilePath
 import           Test.Hspec
@@ -47,7 +48,10 @@ spec =
               pkg <- readPackageFromCabal cabalFp
               Right (_, pkg') <- readPackageConfig expectationFp
               -- ByteString.writeFile (cabalFp ++ ".yaml.out.2") (encodePackage pkg')
-              encodePackage pkg' `shouldBe` encodePackage pkg
+
+              -- This is here to make sure encoding is consistent with the cabal
+              -- file encoding
+              ByteString.unpack (encodePackage pkg') `shouldBe` ByteString.unpack (encodePackage pkg)
 
     describe "simple generated cabal file" $ do
       it "cabal init -m" $ do

--- a/test/Hpack/ConvertSpec.hs
+++ b/test/Hpack/ConvertSpec.hs
@@ -1,0 +1,445 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Hpack.ConvertSpec (spec) where
+
+import           Prelude ()
+import           Prelude.Compat
+
+import           Control.Monad
+import qualified Data.ByteString as ByteString
+import           System.Directory
+import           System.FilePath
+import           Test.Hspec
+
+import           Hpack.Config
+import           Hpack.Convert
+
+spec :: Spec
+spec =
+  describe "fromPackageDescriptionString" $ do
+    describe "generated from ./test/data/*.{cabal,yaml}" $ do
+      cabalFiles <- runIO $ do
+        fs <- getDirectoryContents "./test/data"
+        return $ map ("./test/data" </>)
+          (filter ((== ".cabal") . takeExtension) fs)
+
+      forM_ cabalFiles $ \cabalFp -> do
+        let expectationFp = cabalFp ++ ".yaml"
+            readPackageFromCabal fp = do
+              cc <- readFile fp
+              let Right pkg = fromPackageDescriptionString cc
+              return pkg
+        expectationExists <- runIO $ doesFileExist expectationFp
+
+        if not expectationExists
+          then do
+            it ("parses " ++ cabalFp)
+              (pendingWith ("no expected output file at " ++ expectationFp))
+            it ("produces the same output from " ++ cabalFp ++ " as from " ++ expectationFp)
+              (pendingWith ("no expected output file at " ++ expectationFp))
+          else do
+            it ("parses " ++ cabalFp) $ do
+              pkg <- readPackageFromCabal cabalFp
+              ecc <- ByteString.readFile expectationFp
+              -- ByteString.writeFile (cabalFp ++ ".yaml.out") bpkg
+              encodePackage pkg `shouldBe` ecc
+
+            it ("produces the same output from " ++ cabalFp ++ " as from " ++ expectationFp) $ do
+              pkg <- readPackageFromCabal cabalFp
+              Right (_, pkg') <- readPackageConfig expectationFp
+              -- ByteString.writeFile (cabalFp ++ ".yaml.out.2") (encodePackage pkg')
+              encodePackage pkg' `shouldBe` encodePackage pkg
+
+    describe "simple generated cabal file" $ do
+      it "cabal init -m" $ do
+        pkgDescription <- readFile "./test/data/cabal-init-minimal.cabal"
+        let pkg = fromPackageDescriptionString pkgDescription
+        pkg `shouldBe` Right Package { packageName = "cabal-init-minimal"
+                                     , packageVersion = "0.1.0.0"
+                                     , packageSynopsis = Nothing
+                                     , packageDescription = Nothing
+                                     , packageHomepage = Nothing
+                                     , packageBugReports = Nothing
+                                     , packageCategory = Nothing
+                                     , packageStability = Nothing
+                                     , packageAuthor = [ "Pedro Tacla Yamada" ]
+                                     , packageMaintainer = [ "tacla.yamada@gmail.com" ]
+                                     , packageCopyright = []
+                                     , packageLicense = Just "PublicDomain"
+                                     , packageLicenseFile = Nothing
+                                     , packageTestedWith = Nothing
+                                     , packageFlags = []
+                                     , packageExtraSourceFiles = ["ChangeLog.md"]
+                                     , packageDataFiles = []
+                                     , packageSourceRepository = Nothing
+                                     , packageLibrary = Just Section { sectionData = Library { libraryExposed = Just True
+                                                                                             , libraryExposedModules = []
+                                                                                             , libraryOtherModules = []
+                                                                                             , libraryReexportedModules = []
+                                                                                             }
+                                                                     , sectionSourceDirs = ["src"]
+                                                                     , sectionDependencies = [ Dependency "base >=4.8 && <4.9" Nothing ]
+                                                                     , sectionDefaultExtensions = []
+                                                                     , sectionOtherExtensions = []
+                                                                     , sectionGhcOptions = []
+                                                                     , sectionGhcProfOptions = []
+                                                                     , sectionCppOptions = []
+                                                                     , sectionCCOptions = []
+                                                                     , sectionCSources = []
+                                                                     , sectionExtraLibDirs = []
+                                                                     , sectionExtraLibraries = []
+                                                                     , sectionIncludeDirs = []
+                                                                     , sectionInstallIncludes = []
+                                                                     , sectionLdOptions = []
+                                                                     , sectionBuildable = Just True
+                                                                     , sectionConditionals = []
+                                                                     , sectionBuildTools = []
+                                                                     }
+                                     , packageExecutables = []
+                                     , packageTests = []
+                                     , packageBenchmarks = []
+                                     }
+
+      it "cabal init -m with executables" $ do
+        pkgDescription <- readFile "./test/data/cabal-init-with-executables.cabal"
+        let pkg = fromPackageDescriptionString pkgDescription
+        pkg `shouldBe` Right Package { packageName = "cabal-init-minimal"
+                                     , packageVersion = "0.1.0.0"
+                                     , packageSynopsis = Nothing
+                                     , packageDescription = Nothing
+                                     , packageHomepage = Nothing
+                                     , packageBugReports = Nothing
+                                     , packageCategory = Nothing
+                                     , packageStability = Nothing
+                                     , packageAuthor = [ "Pedro Tacla Yamada" ]
+                                     , packageMaintainer = [ "tacla.yamada@gmail.com" ]
+                                     , packageCopyright = []
+                                     , packageLicense = Just "PublicDomain"
+                                     , packageLicenseFile = Nothing
+                                     , packageTestedWith = Nothing
+                                     , packageFlags = []
+                                     , packageExtraSourceFiles = ["ChangeLog.md"]
+                                     , packageDataFiles = []
+                                     , packageSourceRepository = Nothing
+                                     , packageLibrary = Nothing
+                                     , packageExecutables = [
+                                             Section { sectionData = Executable { executableName = "hello-world"
+                                                                                , executableMain = "HelloWorld.hs"
+                                                                                , executableOtherModules = []
+                                                                                }
+                                                     , sectionSourceDirs = [ "src" ]
+                                                     , sectionDependencies = [ Dependency "base >=4.8 && <4.9" Nothing ]
+                                                     , sectionDefaultExtensions = []
+                                                     , sectionOtherExtensions = []
+                                                     , sectionGhcOptions = []
+                                                     , sectionGhcProfOptions = []
+                                                     , sectionCppOptions = []
+                                                     , sectionCCOptions = []
+                                                     , sectionCSources = []
+                                                     , sectionExtraLibDirs = []
+                                                     , sectionExtraLibraries = []
+                                                     , sectionIncludeDirs = []
+                                                     , sectionInstallIncludes = []
+                                                     , sectionLdOptions = []
+                                                     , sectionBuildable = Just True
+                                                     , sectionConditionals = []
+                                                     , sectionBuildTools = []
+                                                     }
+                                             ]
+                                     , packageTests = []
+                                     , packageBenchmarks = []
+                                     }
+
+      it "cabal init -m with test-suites" $ do
+        pkgDescription <- readFile "./test/data/cabal-init-with-tests.cabal"
+        let pkg = fromPackageDescriptionString pkgDescription
+        pkg `shouldBe` Right Package { packageName = "cabal-init-minimal"
+                                     , packageVersion = "0.1.0.0"
+                                     , packageSynopsis = Nothing
+                                     , packageDescription = Nothing
+                                     , packageHomepage = Nothing
+                                     , packageBugReports = Nothing
+                                     , packageCategory = Nothing
+                                     , packageStability = Nothing
+                                     , packageAuthor = [ "Pedro Tacla Yamada" ]
+                                     , packageMaintainer = [ "tacla.yamada@gmail.com" ]
+                                     , packageCopyright = []
+                                     , packageLicense = Just "PublicDomain"
+                                     , packageLicenseFile = Nothing
+                                     , packageTestedWith = Nothing
+                                     , packageFlags = []
+                                     , packageExtraSourceFiles = ["ChangeLog.md"]
+                                     , packageDataFiles = []
+                                     , packageSourceRepository = Nothing
+                                     , packageLibrary = Nothing
+                                     , packageExecutables = [
+                                             Section { sectionData = Executable { executableName = "hello-world"
+                                                                                , executableMain = "HelloWorld.hs"
+                                                                                , executableOtherModules = []
+                                                                                }
+                                                     , sectionSourceDirs = [ "src" ]
+                                                     , sectionDependencies = [ Dependency "base >=4.8 && <4.9" Nothing ]
+                                                     , sectionDefaultExtensions = []
+                                                     , sectionOtherExtensions = []
+                                                     , sectionGhcOptions = []
+                                                     , sectionGhcProfOptions = []
+                                                     , sectionCppOptions = []
+                                                     , sectionCCOptions = []
+                                                     , sectionCSources = []
+                                                     , sectionExtraLibDirs = []
+                                                     , sectionExtraLibraries = []
+                                                     , sectionIncludeDirs = []
+                                                     , sectionInstallIncludes = []
+                                                     , sectionLdOptions = []
+                                                     , sectionBuildable = Just True
+                                                     , sectionConditionals = []
+                                                     , sectionBuildTools = []
+                                                     }
+                                             ]
+                                     , packageTests = [
+                                             Section { sectionData = Executable { executableName = "hello-world-spec"
+                                                                                , executableMain = "Spec.hs"
+                                                                                , executableOtherModules = []
+                                                                                }
+                                                     , sectionSourceDirs = [ "src", "test" ]
+                                                     , sectionDependencies = [ Dependency "base >=4.8 && <4.9" Nothing ]
+                                                     , sectionDefaultExtensions = []
+                                                     , sectionOtherExtensions = []
+                                                     , sectionGhcOptions = []
+                                                     , sectionGhcProfOptions = []
+                                                     , sectionCppOptions = []
+                                                     , sectionCCOptions = []
+                                                     , sectionCSources = []
+                                                     , sectionExtraLibDirs = []
+                                                     , sectionExtraLibraries = []
+                                                     , sectionIncludeDirs = []
+                                                     , sectionInstallIncludes = []
+                                                     , sectionLdOptions = []
+                                                     , sectionBuildable = Just True
+                                                     , sectionConditionals = []
+                                                     , sectionBuildTools = []
+                                                     }
+                                                      ]
+                                     , packageBenchmarks = []
+                                     }
+
+      it "cabal init -m with benchmarks" $ do
+        pkgDescription <- readFile "./test/data/cabal-init-with-benchmarks.cabal"
+        let pkg = fromPackageDescriptionString pkgDescription
+        pkg `shouldBe` Right Package { packageName = "cabal-init-minimal"
+                                     , packageVersion = "0.1.0.0"
+                                     , packageSynopsis = Nothing
+                                     , packageDescription = Nothing
+                                     , packageHomepage = Nothing
+                                     , packageBugReports = Nothing
+                                     , packageCategory = Nothing
+                                     , packageStability = Nothing
+                                     , packageAuthor = [ "Pedro Tacla Yamada" ]
+                                     , packageMaintainer = [ "tacla.yamada@gmail.com" ]
+                                     , packageCopyright = []
+                                     , packageLicense = Just "PublicDomain"
+                                     , packageLicenseFile = Nothing
+                                     , packageTestedWith = Nothing
+                                     , packageFlags = []
+                                     , packageExtraSourceFiles = ["ChangeLog.md"]
+                                     , packageDataFiles = []
+                                     , packageSourceRepository = Nothing
+                                     , packageLibrary = Nothing
+                                     , packageExecutables = [
+                                             Section { sectionData = Executable { executableName = "hello-world"
+                                                                                , executableMain = "HelloWorld.hs"
+                                                                                , executableOtherModules = []
+                                                                                }
+                                                     , sectionSourceDirs = [ "src" ]
+                                                     , sectionDependencies = [ Dependency "base >=4.8 && <4.9" Nothing ]
+                                                     , sectionDefaultExtensions = []
+                                                     , sectionOtherExtensions = []
+                                                     , sectionGhcOptions = []
+                                                     , sectionGhcProfOptions = []
+                                                     , sectionCppOptions = []
+                                                     , sectionCCOptions = []
+                                                     , sectionCSources = []
+                                                     , sectionExtraLibDirs = []
+                                                     , sectionExtraLibraries = []
+                                                     , sectionIncludeDirs = []
+                                                     , sectionInstallIncludes = []
+                                                     , sectionLdOptions = []
+                                                     , sectionBuildable = Just True
+                                                     , sectionConditionals = []
+                                                     , sectionBuildTools = []
+                                                     }
+                                             ]
+                                     , packageTests = [
+                                             Section { sectionData = Executable { executableName = "hello-world-spec"
+                                                                                , executableMain = "Spec.hs"
+                                                                                , executableOtherModules = []
+                                                                                }
+                                                     , sectionSourceDirs = [ "src", "test" ]
+                                                     , sectionDependencies = [ Dependency "base >=4.8 && <4.9" Nothing ]
+                                                     , sectionDefaultExtensions = []
+                                                     , sectionOtherExtensions = []
+                                                     , sectionGhcOptions = []
+                                                     , sectionGhcProfOptions = []
+                                                     , sectionCppOptions = []
+                                                     , sectionCCOptions = []
+                                                     , sectionCSources = []
+                                                     , sectionExtraLibDirs = []
+                                                     , sectionExtraLibraries = []
+                                                     , sectionIncludeDirs = []
+                                                     , sectionInstallIncludes = []
+                                                     , sectionLdOptions = []
+                                                     , sectionBuildable = Just True
+                                                     , sectionConditionals = []
+                                                     , sectionBuildTools = []
+                                                     }
+                                                      ]
+                                     , packageBenchmarks = [
+                                             Section { sectionData = Executable { executableName = "hello-world-benchmark"
+                                                                                , executableMain = "Bench.hs"
+                                                                                , executableOtherModules = []
+                                                                                }
+                                                     , sectionSourceDirs = [ "src", "benchmarks" ]
+                                                     , sectionDependencies = [ Dependency "base >=4.8 && <4.9" Nothing ]
+                                                     , sectionDefaultExtensions = []
+                                                     , sectionOtherExtensions = []
+                                                     , sectionGhcOptions = []
+                                                     , sectionGhcProfOptions = []
+                                                     , sectionCppOptions = []
+                                                     , sectionCCOptions = []
+                                                     , sectionCSources = []
+                                                     , sectionExtraLibDirs = []
+                                                     , sectionExtraLibraries = []
+                                                     , sectionIncludeDirs = []
+                                                     , sectionInstallIncludes = []
+                                                     , sectionLdOptions = []
+                                                     , sectionBuildable = Just True
+                                                     , sectionConditionals = []
+                                                     , sectionBuildTools = []
+                                                     }
+                                             ]
+                                     }
+
+      it "cabal init -m with conditionals" $ do
+        pkgDescription <- readFile "./test/data/cabal-init-with-conditionals.cabal"
+        let pkg = fromPackageDescriptionString pkgDescription
+        pkg `shouldBe` Right Package { packageName = "cabal-init-minimal"
+                                     , packageVersion = "0.1.0.0"
+                                     , packageSynopsis = Nothing
+                                     , packageDescription = Nothing
+                                     , packageHomepage = Nothing
+                                     , packageBugReports = Nothing
+                                     , packageCategory = Nothing
+                                     , packageStability = Nothing
+                                     , packageAuthor = [ "Pedro Tacla Yamada" ]
+                                     , packageMaintainer = [ "tacla.yamada@gmail.com" ]
+                                     , packageCopyright = []
+                                     , packageLicense = Just "PublicDomain"
+                                     , packageLicenseFile = Nothing
+                                     , packageTestedWith = Nothing
+                                     , packageFlags = []
+                                     , packageExtraSourceFiles = ["ChangeLog.md"]
+                                     , packageDataFiles = []
+                                     , packageSourceRepository = Nothing
+                                     , packageLibrary = Nothing
+                                     , packageExecutables = [
+                                             Section { sectionData = Executable { executableName = "hello-world"
+                                                                                , executableMain = "HelloWorld.hs"
+                                                                                , executableOtherModules = []
+                                                                                }
+                                                     , sectionSourceDirs = [ "src" ]
+                                                     , sectionDependencies = [ Dependency "base >=4.8 && <4.9" Nothing ]
+                                                     , sectionDefaultExtensions = []
+                                                     , sectionOtherExtensions = []
+                                                     , sectionGhcOptions = []
+                                                     , sectionGhcProfOptions = []
+                                                     , sectionCppOptions = []
+                                                     , sectionCCOptions = []
+                                                     , sectionCSources = []
+                                                     , sectionExtraLibDirs = []
+                                                     , sectionExtraLibraries = []
+                                                     , sectionIncludeDirs = []
+                                                     , sectionInstallIncludes = []
+                                                     , sectionLdOptions = []
+                                                     , sectionBuildable = Just True
+                                                     , sectionConditionals = [ Conditional "os(osx)" (emptySection {sectionBuildable = Just False}) Nothing
+                                                                             ]
+                                                     , sectionBuildTools = []
+                                                     }
+                                             ]
+                                     , packageTests = []
+                                     , packageBenchmarks = []
+                                     }
+
+      it "cabal init -m with conditionals and an else branch" $ do
+        pkgDescription <- readFile "./test/data/cabal-init-with-conditionals-and-else.cabal"
+        let pkg = fromPackageDescriptionString pkgDescription
+        pkg `shouldBe` Right Package { packageName = "cabal-init-minimal"
+                                     , packageVersion = "0.1.0.0"
+                                     , packageSynopsis = Nothing
+                                     , packageDescription = Nothing
+                                     , packageHomepage = Nothing
+                                     , packageBugReports = Nothing
+                                     , packageCategory = Nothing
+                                     , packageStability = Nothing
+                                     , packageAuthor = [ "Pedro Tacla Yamada" ]
+                                     , packageMaintainer = [ "tacla.yamada@gmail.com" ]
+                                     , packageCopyright = []
+                                     , packageLicense = Just "PublicDomain"
+                                     , packageLicenseFile = Nothing
+                                     , packageTestedWith = Nothing
+                                     , packageFlags = []
+                                     , packageExtraSourceFiles = ["ChangeLog.md"]
+                                     , packageDataFiles = []
+                                     , packageSourceRepository = Nothing
+                                     , packageLibrary = Nothing
+                                     , packageExecutables = [
+                                             Section { sectionData = Executable { executableName = "hello-world"
+                                                                                , executableMain = "HelloWorld.hs"
+                                                                                , executableOtherModules = []
+                                                                                }
+                                                     , sectionSourceDirs = [ "src" ]
+                                                     , sectionDependencies = [ Dependency "base >=4.8 && <4.9" Nothing ]
+                                                     , sectionDefaultExtensions = []
+                                                     , sectionOtherExtensions = []
+                                                     , sectionGhcOptions = []
+                                                     , sectionGhcProfOptions = []
+                                                     , sectionCppOptions = []
+                                                     , sectionCCOptions = []
+                                                     , sectionCSources = []
+                                                     , sectionExtraLibDirs = []
+                                                     , sectionExtraLibraries = []
+                                                     , sectionIncludeDirs = []
+                                                     , sectionInstallIncludes = []
+                                                     , sectionLdOptions = []
+                                                     , sectionBuildable = Just True
+                                                     , sectionConditionals = [
+                                                             Conditional "os(osx)"
+                                                             (emptySection {sectionSourceDirs = ["osx"]})
+                                                             (Just emptySection {sectionSourceDirs = ["notosx"]})
+                                                             ]
+                                                     , sectionBuildTools = []
+                                                     }
+                                             ]
+                                     , packageTests = []
+                                     , packageBenchmarks = []
+                                     }
+
+emptySection :: Section ()
+emptySection = Section { sectionData = ()
+                       , sectionSourceDirs = []
+                       , sectionDependencies = []
+                       , sectionDefaultExtensions = []
+                       , sectionOtherExtensions = []
+                       , sectionGhcOptions = []
+                       , sectionGhcProfOptions = []
+                       , sectionCppOptions = []
+                       , sectionCCOptions = []
+                       , sectionCSources = []
+                       , sectionExtraLibDirs = []
+                       , sectionExtraLibraries = []
+                       , sectionIncludeDirs = []
+                       , sectionInstallIncludes = []
+                       , sectionLdOptions = []
+                       , sectionBuildable = Just True
+                       , sectionConditionals = []
+                       , sectionBuildTools = []
+                       }

--- a/test/HpackSpec.hs
+++ b/test/HpackSpec.hs
@@ -5,13 +5,15 @@ import           Prelude.Compat
 
 import           Control.Monad.Compat
 import           Control.DeepSeq
-import           Data.Version (Version(..), showVersion)
+import           Data.Version (Version (..), showVersion)
 
 import           Test.Hspec
 import           Test.Mockery.Directory
 import           Test.QuickCheck
 
 import           Hpack
+import           Hpack.Config
+import           Hpack.Convert
 
 makeVersion :: [Int] -> Version
 makeVersion v = Version v []

--- a/test/data/cabal-init-minimal.cabal
+++ b/test/data/cabal-init-minimal.cabal
@@ -1,0 +1,13 @@
+name:                cabal-init-minimal
+version:             0.1.0.0
+license:             PublicDomain
+author:              Pedro Tacla Yamada
+maintainer:          tacla.yamada@gmail.com
+build-type:          Simple
+extra-source-files:  ChangeLog.md
+cabal-version:       >=1.10
+
+library
+  build-depends:       base >=4.8 && <4.9
+  hs-source-dirs:      src
+  default-language:    Haskell2010

--- a/test/data/cabal-init-minimal.cabal.yaml
+++ b/test/data/cabal-init-minimal.cabal.yaml
@@ -1,0 +1,11 @@
+name: cabal-init-minimal
+version: '0.1.0.0'
+author: Pedro Tacla Yamada
+maintainer: tacla.yamada@gmail.com
+license: PublicDomain
+extra-source-files:
+- ChangeLog.md
+dependencies:
+- base >=4.8 && <4.9
+library:
+  source-dirs: src

--- a/test/data/cabal-init-with-benchmarks.cabal
+++ b/test/data/cabal-init-with-benchmarks.cabal
@@ -1,0 +1,30 @@
+name:                cabal-init-minimal
+version:             0.1.0.0
+license:             PublicDomain
+author:              Pedro Tacla Yamada
+maintainer:          tacla.yamada@gmail.com
+build-type:          Simple
+extra-source-files:  ChangeLog.md
+cabal-version:       >=1.10
+
+executable hello-world
+  main-is: HelloWorld.hs
+  build-depends: base >=4.8 && <4.9
+  hs-source-dirs: src
+  default-language: Haskell2010
+
+test-suite hello-world-spec
+  main-is: Spec.hs
+  type: exitcode-stdio-1.0
+  build-depends: base >=4.8 && <4.9
+  hs-source-dirs: src
+                , test
+  default-language: Haskell2010
+
+benchmark hello-world-benchmark
+  main-is: Bench.hs
+  type: exitcode-stdio-1.0
+  build-depends: base >=4.8 && <4.9
+  hs-source-dirs: src
+                , benchmarks
+  default-language: Haskell2010

--- a/test/data/cabal-init-with-benchmarks.cabal.yaml
+++ b/test/data/cabal-init-with-benchmarks.cabal.yaml
@@ -1,0 +1,25 @@
+name: cabal-init-minimal
+version: '0.1.0.0'
+author: Pedro Tacla Yamada
+maintainer: tacla.yamada@gmail.com
+license: PublicDomain
+extra-source-files:
+- ChangeLog.md
+dependencies:
+- base >=4.8 && <4.9
+executables:
+  hello-world:
+    main: HelloWorld.hs
+    source-dirs: src
+tests:
+  hello-world-spec:
+    main: Spec.hs
+    source-dirs:
+    - src
+    - test
+benchmarks:
+  hello-world-benchmark:
+    main: Bench.hs
+    source-dirs:
+    - src
+    - benchmarks

--- a/test/data/cabal-init-with-conditionals-and-else.cabal
+++ b/test/data/cabal-init-with-conditionals-and-else.cabal
@@ -1,0 +1,19 @@
+name:                cabal-init-minimal
+version:             0.1.0.0
+license:             PublicDomain
+author:              Pedro Tacla Yamada
+maintainer:          tacla.yamada@gmail.com
+build-type:          Simple
+extra-source-files:  ChangeLog.md
+cabal-version:       >=1.10
+
+executable hello-world
+  main-is: HelloWorld.hs
+  build-depends: base >=4.8 && <4.9
+  hs-source-dirs: src
+  default-language: Haskell2010
+
+  if os(darwin)
+     hs-source-dirs: osx
+  else
+     hs-source-dirs: notosx

--- a/test/data/cabal-init-with-conditionals-and-else.cabal.yaml
+++ b/test/data/cabal-init-with-conditionals-and-else.cabal.yaml
@@ -1,0 +1,19 @@
+name: cabal-init-minimal
+version: '0.1.0.0'
+author: Pedro Tacla Yamada
+maintainer: tacla.yamada@gmail.com
+license: PublicDomain
+extra-source-files:
+- ChangeLog.md
+dependencies:
+- base >=4.8 && <4.9
+executables:
+  hello-world:
+    main: HelloWorld.hs
+    source-dirs: src
+    when:
+    - condition: os(osx)
+      then:
+        source-dirs: osx
+      else:
+        source-dirs: notosx

--- a/test/data/cabal-init-with-conditionals-buildable.cabal
+++ b/test/data/cabal-init-with-conditionals-buildable.cabal
@@ -1,0 +1,19 @@
+name:                cabal-init-minimal
+version:             0.1.0.0
+license:             PublicDomain
+author:              Pedro Tacla Yamada
+maintainer:          tacla.yamada@gmail.com
+build-type:          Simple
+extra-source-files:  ChangeLog.md
+cabal-version:       >=1.10
+
+executable hello-world
+  main-is: HelloWorld.hs
+  build-depends: base >=4.8 && <4.9
+  hs-source-dirs: src
+  default-language: Haskell2010
+
+  if os(darwin)
+    buildable: True
+  else
+    buildable: False

--- a/test/data/cabal-init-with-conditionals-buildable.cabal.yaml
+++ b/test/data/cabal-init-with-conditionals-buildable.cabal.yaml
@@ -1,0 +1,16 @@
+name: cabal-init-minimal
+version: '0.1.0.0'
+author: Pedro Tacla Yamada
+maintainer: tacla.yamada@gmail.com
+license: PublicDomain
+extra-source-files:
+- ChangeLog.md
+dependencies:
+- base >=4.8 && <4.9
+executables:
+  hello-world:
+    main: HelloWorld.hs
+    source-dirs: src
+    when:
+    - condition: ! '!(os(osx))'
+      buildable: false

--- a/test/data/cabal-init-with-conditionals-buildable2.cabal
+++ b/test/data/cabal-init-with-conditionals-buildable2.cabal
@@ -1,0 +1,29 @@
+name:                cabal-init-minimal
+version:             0.1.0.0
+license:             PublicDomain
+author:              Pedro Tacla Yamada
+maintainer:          tacla.yamada@gmail.com
+build-type:          Simple
+extra-source-files:  ChangeLog.md
+cabal-version:       >=1.10
+
+Flag Something
+  default: False
+
+Flag SomethingElse
+  default: False
+
+executable hello-world
+  main-is: HelloWorld.hs
+  build-depends: base >=4.8 && <4.9
+  hs-source-dirs: src
+  default-language: Haskell2010
+
+  if os(darwin)
+    buildable: True
+    if flag(Something)
+      buildable: True
+      if flag(SomethingElse)
+        buildable: False
+  else
+    buildable: False

--- a/test/data/cabal-init-with-conditionals-buildable2.cabal.yaml
+++ b/test/data/cabal-init-with-conditionals-buildable2.cabal.yaml
@@ -1,0 +1,32 @@
+name: cabal-init-minimal
+version: '0.1.0.0'
+author: Pedro Tacla Yamada
+maintainer: tacla.yamada@gmail.com
+license: PublicDomain
+extra-source-files:
+- ChangeLog.md
+dependencies:
+- base >=4.8 && <4.9
+executables:
+  hello-world:
+    main: HelloWorld.hs
+    source-dirs: src
+    when:
+    - condition: os(osx)
+      then:
+        when:
+        - condition: flag(something)
+          when:
+          - condition: flag(somethingelse)
+            buildable: false
+      else:
+        buildable: false
+flags:
+  somethingelse:
+    description: null
+    manual: false
+    default: false
+  something:
+    description: null
+    manual: false
+    default: false

--- a/test/data/cabal-init-with-conditionals-buildable3.cabal
+++ b/test/data/cabal-init-with-conditionals-buildable3.cabal
@@ -1,0 +1,30 @@
+name:                cabal-init-minimal
+version:             0.1.0.0
+license:             PublicDomain
+author:              Pedro Tacla Yamada
+maintainer:          tacla.yamada@gmail.com
+build-type:          Simple
+extra-source-files:  ChangeLog.md
+cabal-version:       >=1.10
+
+Flag Something
+  default: False
+
+Flag SomethingElse
+  default: False
+
+executable hello-world
+  main-is: HelloWorld.hs
+  build-depends: base >=4.8 && <4.9
+  hs-source-dirs: src
+  default-language: Haskell2010
+  buildable: False
+
+  if os(darwin)
+    buildable: True
+    if flag(Something)
+      buildable: True
+      if flag(SomethingElse)
+        buildable: False
+  else
+    buildable: False

--- a/test/data/cabal-init-with-conditionals-buildable3.cabal.yaml
+++ b/test/data/cabal-init-with-conditionals-buildable3.cabal.yaml
@@ -1,0 +1,31 @@
+name: cabal-init-minimal
+version: '0.1.0.0'
+author: Pedro Tacla Yamada
+maintainer: tacla.yamada@gmail.com
+license: PublicDomain
+extra-source-files:
+- ChangeLog.md
+dependencies:
+- base >=4.8 && <4.9
+executables:
+  hello-world:
+    main: HelloWorld.hs
+    source-dirs: src
+    buildable: false
+    when:
+    - condition: os(osx)
+      buildable: true
+      when:
+      - condition: flag(something)
+        when:
+        - condition: flag(somethingelse)
+          buildable: false
+flags:
+  somethingelse:
+    description: null
+    manual: false
+    default: false
+  something:
+    description: null
+    manual: false
+    default: false

--- a/test/data/cabal-init-with-conditionals-buildable4.cabal
+++ b/test/data/cabal-init-with-conditionals-buildable4.cabal
@@ -1,0 +1,19 @@
+name:                cabal-init-minimal
+version:             0.1.0.0
+license:             PublicDomain
+author:              Pedro Tacla Yamada
+maintainer:          tacla.yamada@gmail.com
+build-type:          Simple
+extra-source-files:  ChangeLog.md
+cabal-version:       >=1.10
+
+executable hello-world
+  main-is: HelloWorld.hs
+  build-depends: base >=4.8 && <4.9
+  hs-source-dirs: src
+  default-language: Haskell2010
+
+  if os(darwin)
+    buildable: True
+  if os(linux)
+    buildable: False

--- a/test/data/cabal-init-with-conditionals-buildable4.cabal.yaml
+++ b/test/data/cabal-init-with-conditionals-buildable4.cabal.yaml
@@ -1,0 +1,16 @@
+name: cabal-init-minimal
+version: '0.1.0.0'
+author: Pedro Tacla Yamada
+maintainer: tacla.yamada@gmail.com
+license: PublicDomain
+extra-source-files:
+- ChangeLog.md
+dependencies:
+- base >=4.8 && <4.9
+executables:
+  hello-world:
+    main: HelloWorld.hs
+    source-dirs: src
+    when:
+    - condition: os(linux)
+      buildable: false

--- a/test/data/cabal-init-with-conditionals-buildable5.cabal
+++ b/test/data/cabal-init-with-conditionals-buildable5.cabal
@@ -1,0 +1,20 @@
+name:                cabal-init-minimal
+version:             0.1.0.0
+license:             PublicDomain
+author:              Pedro Tacla Yamada
+maintainer:          tacla.yamada@gmail.com
+build-type:          Simple
+extra-source-files:  ChangeLog.md
+cabal-version:       >=1.10
+
+executable hello-world
+  main-is: HelloWorld.hs
+  build-depends: base >=4.8 && <4.9
+  hs-source-dirs: src
+  default-language: Haskell2010
+  buildable: False
+
+  if os(darwin)
+    buildable: True
+  if os(linux)
+    buildable: False

--- a/test/data/cabal-init-with-conditionals-buildable5.cabal.yaml
+++ b/test/data/cabal-init-with-conditionals-buildable5.cabal.yaml
@@ -1,0 +1,17 @@
+name: cabal-init-minimal
+version: '0.1.0.0'
+author: Pedro Tacla Yamada
+maintainer: tacla.yamada@gmail.com
+license: PublicDomain
+extra-source-files:
+- ChangeLog.md
+dependencies:
+- base >=4.8 && <4.9
+executables:
+  hello-world:
+    main: HelloWorld.hs
+    source-dirs: src
+    buildable: false
+    when:
+    - condition: os(osx)
+      buildable: true

--- a/test/data/cabal-init-with-conditionals.cabal
+++ b/test/data/cabal-init-with-conditionals.cabal
@@ -1,0 +1,17 @@
+name:                cabal-init-minimal
+version:             0.1.0.0
+license:             PublicDomain
+author:              Pedro Tacla Yamada
+maintainer:          tacla.yamada@gmail.com
+build-type:          Simple
+extra-source-files:  ChangeLog.md
+cabal-version:       >=1.10
+
+executable hello-world
+  main-is: HelloWorld.hs
+  build-depends: base >=4.8 && <4.9
+  hs-source-dirs: src
+  default-language: Haskell2010
+
+  if os(darwin)
+     buildable: False

--- a/test/data/cabal-init-with-conditionals.cabal.yaml
+++ b/test/data/cabal-init-with-conditionals.cabal.yaml
@@ -1,0 +1,16 @@
+name: cabal-init-minimal
+version: '0.1.0.0'
+author: Pedro Tacla Yamada
+maintainer: tacla.yamada@gmail.com
+license: PublicDomain
+extra-source-files:
+- ChangeLog.md
+dependencies:
+- base >=4.8 && <4.9
+executables:
+  hello-world:
+    main: HelloWorld.hs
+    source-dirs: src
+    when:
+    - condition: os(osx)
+      buildable: false

--- a/test/data/cabal-init-with-executables.cabal
+++ b/test/data/cabal-init-with-executables.cabal
@@ -1,0 +1,14 @@
+name:                cabal-init-minimal
+version:             0.1.0.0
+license:             PublicDomain
+author:              Pedro Tacla Yamada
+maintainer:          tacla.yamada@gmail.com
+build-type:          Simple
+extra-source-files:  ChangeLog.md
+cabal-version:       >=1.10
+
+executable hello-world
+  main-is: HelloWorld.hs
+  build-depends: base >=4.8 && <4.9
+  hs-source-dirs: src
+  default-language: Haskell2010

--- a/test/data/cabal-init-with-executables.cabal.yaml
+++ b/test/data/cabal-init-with-executables.cabal.yaml
@@ -1,0 +1,13 @@
+name: cabal-init-minimal
+version: '0.1.0.0'
+author: Pedro Tacla Yamada
+maintainer: tacla.yamada@gmail.com
+license: PublicDomain
+extra-source-files:
+- ChangeLog.md
+dependencies:
+- base >=4.8 && <4.9
+executables:
+  hello-world:
+    main: HelloWorld.hs
+    source-dirs: src

--- a/test/data/cabal-init-with-tests.cabal
+++ b/test/data/cabal-init-with-tests.cabal
@@ -1,0 +1,22 @@
+name:                cabal-init-minimal
+version:             0.1.0.0
+license:             PublicDomain
+author:              Pedro Tacla Yamada
+maintainer:          tacla.yamada@gmail.com
+build-type:          Simple
+extra-source-files:  ChangeLog.md
+cabal-version:       >=1.10
+
+executable hello-world
+  main-is: HelloWorld.hs
+  build-depends: base >=4.8 && <4.9
+  hs-source-dirs: src
+  default-language: Haskell2010
+
+test-suite hello-world-spec
+  main-is: Spec.hs
+  type: exitcode-stdio-1.0
+  build-depends: base >=4.8 && <4.9
+  hs-source-dirs: src
+                , test
+  default-language: Haskell2010

--- a/test/data/cabal-init-with-tests.cabal.yaml
+++ b/test/data/cabal-init-with-tests.cabal.yaml
@@ -1,0 +1,19 @@
+name: cabal-init-minimal
+version: '0.1.0.0'
+author: Pedro Tacla Yamada
+maintainer: tacla.yamada@gmail.com
+license: PublicDomain
+extra-source-files:
+- ChangeLog.md
+dependencies:
+- base >=4.8 && <4.9
+executables:
+  hello-world:
+    main: HelloWorld.hs
+    source-dirs: src
+tests:
+  hello-world-spec:
+    main: Spec.hs
+    source-dirs:
+    - src
+    - test

--- a/test/data/getopt-generics.cabal
+++ b/test/data/getopt-generics.cabal
@@ -1,0 +1,106 @@
+-- This file has been generated from package.yaml by hpack version 0.5.4.
+--
+-- see: https://github.com/sol/hpack
+
+name:           getopt-generics
+version:        0.13
+synopsis:       Create command line interfaces with ease
+description:    Create command line interfaces with ease
+category:       Console, System
+homepage:       https://github.com/soenkehahn/getopt-generics#readme
+bug-reports:    https://github.com/soenkehahn/getopt-generics/issues
+author:         Linh Nguyen, Sönke Hahn
+maintainer:     linh.nguyen@zalora.com, soenkehahn@gmail.com
+copyright:      Zalora South East Asia Pte Ltd
+license:        BSD3
+license-file:   LICENSE
+build-type:     Simple
+cabal-version:  >=1.10
+
+extra-source-files:
+    docs/stuff
+
+source-repository head
+  type: git
+  location: https://github.com/soenkehahn/getopt-generics
+
+library
+  hs-source-dirs:
+      src
+  ghc-options: -Wall -fno-warn-name-shadowing
+  build-depends:
+      base ==4.*
+    , base-compat >=0.8
+    , base-orphans
+    , generics-sop >=0.1 && <0.3
+    , tagged
+  exposed-modules:
+      WithCli
+      WithCli.Pure
+  other-modules:
+      WithCli.Argument
+      WithCli.Flag
+      WithCli.HasArguments
+      WithCli.Modifier
+      WithCli.Modifier.Types
+      WithCli.Normalize
+      WithCli.Parser
+      WithCli.Pure.Internal
+      WithCli.Result
+  default-language: Haskell2010
+
+test-suite spec
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  hs-source-dirs:
+      src
+    , test
+    , docs
+  ghc-options: -Wall -fno-warn-name-shadowing -threaded -O0
+  build-depends:
+      base ==4.*
+    , base-compat >=0.8
+    , base-orphans
+    , generics-sop >=0.1 && <0.3
+    , tagged
+    , hspec >=2.1.8
+    , QuickCheck
+    , silently
+    , filepath
+    , safe
+  other-modules:
+      WithCli
+      WithCli.Argument
+      WithCli.Flag
+      WithCli.HasArguments
+      WithCli.Modifier
+      WithCli.Modifier.Types
+      WithCli.Normalize
+      WithCli.Parser
+      WithCli.Pure
+      WithCli.Pure.Internal
+      WithCli.Result
+      DocsSpec
+      ModifiersSpec
+      ModifiersSpec.RenameOptionsSpec
+      ModifiersSpec.UseForPositionalArgumentsSpec
+      ShellProtocol
+      Util
+      WithCli.ArgumentSpec
+      WithCli.HasArgumentsSpec
+      WithCli.ModifierSpec
+      WithCli.NormalizeSpec
+      WithCli.ParserSpec
+      WithCli.Pure.RecordSpec
+      WithCli.PureSpec
+      WithCli.ResultSpec
+      WithCliSpec
+      CustomOption
+      CustomOptionRecord
+      RecordType
+      Simple
+      Test01
+      Test02
+      Test03
+      Test04
+  default-language: Haskell2010

--- a/test/data/getopt-generics.cabal.yaml
+++ b/test/data/getopt-generics.cabal.yaml
@@ -1,0 +1,42 @@
+name: getopt-generics
+version: '0.13'
+synopsis: Create command line interfaces with ease
+description: Create command line interfaces with ease
+category: Console, System
+author: Linh Nguyen, Sönke Hahn
+maintainer: linh.nguyen@zalora.com, soenkehahn@gmail.com
+copyright: Zalora South East Asia Pte Ltd
+license: BSD3
+github: soenkehahn/getopt-generics
+extra-source-files:
+- docs/stuff
+ghc-options:
+- -Wall
+- -fno-warn-name-shadowing
+dependencies:
+- base ==4.*
+- base-compat >=0.8
+- base-orphans
+- generics-sop >=0.1 && <0.3
+- tagged
+library:
+  source-dirs: src
+  exposed-modules:
+  - WithCli
+  - WithCli.Pure
+tests:
+  spec:
+    main: Spec.hs
+    source-dirs:
+    - src
+    - test
+    - docs
+    ghc-options:
+    - -threaded
+    - -O0
+    dependencies:
+    - hspec >=2.1.8
+    - QuickCheck
+    - silently
+    - filepath
+    - safe

--- a/test/data/hpack.cabal
+++ b/test/data/hpack.cabal
@@ -25,6 +25,8 @@ library
   build-depends:
       base >= 4.7 && < 5
     , base-compat >= 0.8
+    , Cabal
+    , pretty
     , deepseq
     , directory
     , filepath
@@ -33,13 +35,17 @@ library
     , containers
     , unordered-containers
     , yaml
-    , aeson >= 0.11
+    , bytestring
+    , vector
+    , aeson >= 0.8
   exposed-modules:
       Hpack
       Hpack.Config
       Hpack.Run
       Hpack.Yaml
   other-modules:
+      Hpack.Convert
+      Hpack.Convert.Run
       Hpack.FormattingHints
       Hpack.GenericsUtil
       Hpack.Haskell
@@ -56,6 +62,8 @@ executable hpack
   build-depends:
       base >= 4.7 && < 5
     , base-compat >= 0.8
+    , Cabal
+    , pretty
     , deepseq
     , directory
     , filepath
@@ -64,6 +72,8 @@ executable hpack
     , containers
     , unordered-containers
     , yaml
+    , bytestring
+    , vector
     , hpack
     , aeson >= 0.8
   default-language: Haskell2010
@@ -79,6 +89,8 @@ test-suite spec
   build-depends:
       base >= 4.7 && < 5
     , base-compat >= 0.8
+    , Cabal
+    , pretty
     , deepseq
     , directory
     , filepath
@@ -87,6 +99,8 @@ test-suite spec
     , containers
     , unordered-containers
     , yaml
+    , bytestring
+    , vector
     , hspec == 2.*
     , QuickCheck
     , temporary
@@ -97,6 +111,7 @@ test-suite spec
   other-modules:
       Helper
       Hpack.ConfigSpec
+      Hpack.ConvertSpec
       Hpack.FormattingHintsSpec
       Hpack.GenericsUtilSpec
       Hpack.HaskellSpec
@@ -106,6 +121,8 @@ test-suite spec
       HpackSpec
       Hpack
       Hpack.Config
+      Hpack.Convert
+      Hpack.Convert.Run
       Hpack.FormattingHints
       Hpack.GenericsUtil
       Hpack.Haskell

--- a/test/data/hpack.cabal.yaml
+++ b/test/data/hpack.cabal.yaml
@@ -1,0 +1,56 @@
+name: hpack
+version: '0.14.1'
+synopsis: An alternative format for Haskell packages
+category: Development
+maintainer: Simon Hengel <sol@typeful.net>
+license: MIT
+github: sol/hpack
+dependencies:
+- base >=4.7 && <5
+- base-compat >=0.8
+- Cabal
+- pretty
+- deepseq
+- directory
+- filepath
+- Glob
+- text
+- containers
+- unordered-containers
+- yaml
+- bytestring
+- vector
+library:
+  source-dirs: src
+  ghc-options: -Wall
+  exposed-modules:
+  - Hpack
+  - Hpack.Config
+  - Hpack.Run
+  - Hpack.Yaml
+  dependencies:
+  - aeson >=0.8
+executables:
+  hpack:
+    main: Main.hs
+    source-dirs: driver
+    ghc-options: -Wall
+    dependencies:
+    - hpack
+    - aeson >=0.8
+tests:
+  spec:
+    main: Spec.hs
+    source-dirs:
+    - test
+    - src
+    ghc-options: -Wall
+    cpp-options: -DTEST
+    dependencies:
+    - hspec ==2.*
+    - QuickCheck
+    - temporary
+    - mockery >=0.3
+    - interpolate
+    - aeson-qq
+    - aeson >=0.10


### PR DESCRIPTION
Adds modules `Hpack.Convert` and `Hpack.Convert.Run` for reading a
`GenericPackageDescription` onto a `Package` and running the user-facing
conversion routine.

The user-facing option is exposed through:
```
$ hpack --convert [cabal-file|project-dir]
```

- - -

Also adds tests testing we can read cabal files generated from some of
the README examples and hpack's into package.yamls that look like the
original ones.

Everything should be supported, including converting conditionals.

I really need feedback on how to make `Hpack.Config` `Package` related
`ToJSON` instances cleaner. That's the ugly bit of the code.

There some cases where we run into problems in conversion. For example,
the Cabal library does not expose in its data-structures if `buildable`
was specified or not. To keep the output clean, I initially striped it
from sections if it was true, but then empty conditional blocks could be
generated. Right now it'll only output `buildable` if it's not
redundant based on context. It'll also remove any empty conditional
branches.

This closes #63.