### PR TITLE
Fix rendering dots in multi-line fields

### DIFF
--- a/hpack.cabal
+++ b/hpack.cabal
@@ -33,7 +33,7 @@ library
     , containers
     , unordered-containers
     , yaml
-    , aeson >= 0.11
+    , aeson >= 0.8
   exposed-modules:
       Hpack
       Hpack.Config

--- a/test/Hpack/RenderSpec.hs
+++ b/test/Hpack/RenderSpec.hs
@@ -72,6 +72,28 @@ spec = do
             let field = Field "foo" (CommaSeparatedList [])
             render_ field `shouldBe` []
 
+        context "when rendering a dot" $ do
+          it "returns the field inline with the field name" $ do
+            let field = Field "foo" (CommaSeparatedList ["something", "."])
+            render defaultRenderSettings 1 field `shouldBe` [
+                "  foo: ."
+              , "    , something"
+              ]
+
+          it "doesn't add commas to non-CommaSeparatedLists" $ do
+            let field = Field "foo" (LineSeparatedList ["something", "."])
+            render defaultRenderSettings{renderSettingsCommaStyle = TrailingCommas} 1 field `shouldBe` [
+                "  foo: ."
+              , "    something"
+              ]
+
+          it "returns normally if the style is TrailingCommas" $ do
+            let field = Field "foo" (CommaSeparatedList ["something", "."])
+            render defaultRenderSettings{renderSettingsCommaStyle = TrailingCommas} 1 field `shouldBe` [
+                "  foo: .,"
+              , "    something"
+              ]
+
       context "when rendering a SingleLine value" $ do
         it "returns a single line" $ do
           let field = Field "foo" (Literal "bar")


### PR DESCRIPTION
This closes #119. By pulling dots to the same line as the field name.

For example:

    source-dirs:
    - .
    - something

Will render as:

    hs-source-dirs: .
                 , something

Or

    hs-source-dirs: .,
                   something

Depending on the comma configuration. Likewise:

    include-dirs:
    - .
    - something

Will render as:

    include-dirs: .
          something