### PR TITLE
Fix rendering dots in multi-line fields (simple)

### DIFF
--- a/hpack.cabal
+++ b/hpack.cabal
@@ -33,7 +33,7 @@ library
     , containers
     , unordered-containers
     , yaml
-    , aeson >= 0.11
+    , aeson >= 0.8
   exposed-modules:
       Hpack
       Hpack.Config

--- a/src/Hpack/Render.hs
+++ b/src/Hpack/Render.hs
@@ -87,16 +87,20 @@ renderValue RenderSettings{..} v = case v of
   CommaSeparatedList xs -> renderCommaSeparatedList renderSettingsCommaStyle xs
 
 renderLineSeparatedList :: CommaStyle -> [String] -> Lines
-renderLineSeparatedList style = MultipleLines . map (padding ++)
+renderLineSeparatedList style = MultipleLines . map (padding ++) . map renderListValue
   where
     padding = case style of
       LeadingCommas -> "  "
       TrailingCommas -> ""
 
+renderListValue :: String -> String
+renderListValue "." = "./."
+renderListValue s = s
+
 renderCommaSeparatedList :: CommaStyle -> [String] -> Lines
 renderCommaSeparatedList style = MultipleLines . case style of
-  LeadingCommas -> map renderLeadingComma . zip (True : repeat False)
-  TrailingCommas -> map renderTrailingComma . reverse . zip (True : repeat False) . reverse
+  LeadingCommas -> map renderLeadingComma . zip (True : repeat False) . map renderListValue
+  TrailingCommas -> map renderTrailingComma . reverse . zip (True : repeat False) . reverse . map renderListValue
   where
     renderLeadingComma :: (Bool, String) -> String
     renderLeadingComma (isFirst, x)

--- a/test/Hpack/RenderSpec.hs
+++ b/test/Hpack/RenderSpec.hs
@@ -72,6 +72,15 @@ spec = do
             let field = Field "foo" (CommaSeparatedList [])
             render_ field `shouldBe` []
 
+        context "when rendering a dot" $ do
+          it "replaces it with ./." $ do
+            let field = Field "foo" (CommaSeparatedList ["something", "."])
+            render defaultRenderSettings 1 field `shouldBe` [
+                "  foo:"
+              , "      something"
+              , "    , ./."
+              ]
+
       context "when rendering a SingleLine value" $ do
         it "returns a single line" $ do
           let field = Field "foo" (Literal "bar")


### PR DESCRIPTION
This closes #119, by replacing `.` with `./.` as suggested by
@soenkehahn.

For example:

    source-dirs:
    - .

Will render as:

    hs-source-dirs:
                   ./.

This supersedes #120.