### PR TITLE
Please support Setup.hs

### DIFF
--- a/src/Hpack.hs
+++ b/src/Hpack.hs
@@ -35,7 +35,7 @@ import           Hpack.Config
 import           Hpack.Run
 
 programVersion :: Version -> String
-programVersion v = "hpack version " ++ Version.showVersion v
+programVersion v = "hpack (custom) version " ++ Version.showVersion v
 
 header :: Version -> String
 header v = unlines [

--- a/src/Hpack.hs
+++ b/src/Hpack.hs
@@ -35,7 +35,7 @@ import           Hpack.Config
 import           Hpack.Run
 
 programVersion :: Version -> String
-programVersion v = "hpack (custom) version " ++ Version.showVersion v
+programVersion v = "hpack version " ++ Version.showVersion v
 
 header :: Version -> String
 header v = unlines [

--- a/src/Hpack/Config.hs
+++ b/src/Hpack/Config.hs
@@ -62,8 +62,8 @@ import           Hpack.GenericsUtil
 import           Hpack.Util
 import           Hpack.Yaml
 
-package :: String -> String -> Package
-package name version = Package name version Nothing Nothing Nothing Nothing Nothing Nothing [] [] [] Nothing Nothing [] Nothing [] [] [] Nothing Nothing [] [] []
+package :: String -> String -> String -> Package
+package name version btype = Package name version Nothing Nothing Nothing Nothing Nothing Nothing [] [] [] Nothing Nothing btype Nothing [] [] [] Nothing Nothing [] [] []
 
 renamePackage :: String -> Package -> Package
 renamePackage name p@Package{..} = p {

--- a/src/Hpack/Config.hs
+++ b/src/Hpack/Config.hs
@@ -63,7 +63,7 @@ import           Hpack.Util
 import           Hpack.Yaml
 
 package :: String -> String -> Package
-package name version = Package name version Nothing Nothing Nothing Nothing Nothing Nothing [] [] [] Nothing Nothing Nothing [] [] [] Nothing Nothing [] [] []
+package name version = Package name version Nothing Nothing Nothing Nothing Nothing Nothing [] [] [] Nothing Nothing [] Nothing [] [] [] Nothing Nothing [] [] []
 
 renamePackage :: String -> Package -> Package
 renamePackage name p@Package{..} = p {
@@ -360,6 +360,7 @@ data Package = Package {
 , packageCopyright :: [String]
 , packageLicense :: Maybe String
 , packageLicenseFile :: Maybe FilePath
+, packageBuildType :: String
 , packageTestedWith :: Maybe String
 , packageFlags :: [Flag]
 , packageExtraSourceFiles :: [FilePath]
@@ -451,6 +452,9 @@ mkPackage dir (CaptureUnknownFields unknownFields globalOptions@Section{sectionD
 
   licenseFileExists <- doesFileExist (dir </> "LICENSE")
 
+  setupFileExists <- liftM2 (||) (doesFileExist $ dir </> "Setup.hs")
+                     (doesFileExist $ dir </> "Setup.lhs")
+
   missingSourceDirs <- nub . sort <$> filterM (fmap not <$> doesDirectoryExist . (dir </>)) (
        maybe [] sectionSourceDirs mLibrary
     ++ concatMap sectionSourceDirs executables
@@ -478,6 +482,7 @@ mkPackage dir (CaptureUnknownFields unknownFields globalOptions@Section{sectionD
       , packageCopyright = fromMaybeList packageConfigCopyright
       , packageLicense = packageConfigLicense
       , packageLicenseFile = packageConfigLicenseFile <|> (guard licenseFileExists >> Just "LICENSE")
+      , packageBuildType = if setupFileExists then "Custom" else "Simple"
       , packageTestedWith = packageConfigTestedWith
       , packageFlags = flags
       , packageExtraSourceFiles = extraSourceFiles

--- a/src/Hpack/Run.hs
+++ b/src/Hpack/Run.hs
@@ -100,7 +100,7 @@ renderPackage settings alignment existingFieldOrder sectionsFieldOrder Package{.
       , ("license", packageLicense)
       , ("license-file", packageLicenseFile)
       , ("tested-with", packageTestedWith)
-      , ("build-type", Just "Simple")
+      , ("build-type", Just packageBuildType)
       , ("cabal-version", cabalVersion)
       ]
 

--- a/test/Hpack/ConfigSpec.hs
+++ b/test/Hpack/ConfigSpec.hs
@@ -24,7 +24,7 @@ import           Hpack.Config hiding (package)
 import qualified Hpack.Config as Config
 
 package :: Package
-package = Config.package "foo" "0.0.0"
+package = Config.package "foo" "0.0.0" "Simple"
 
 executable :: String -> String -> Executable
 executable name main_ = Executable name main_ []


### PR DESCRIPTION
Especially in complex project setups where a package configuration with hpack is a big benefit, it is highly likely that the build process is tuned with a custom build type (to be found in Setup.hs).

This patch tries to figure out whether such a custom build setup is in place, and sets the Cabal entry accordingly.