### PR TITLE
Update stack.yaml to use aeson-1.0.0.0

### DIFF
--- a/hpack.cabal
+++ b/hpack.cabal
@@ -1,4 +1,4 @@
--- This file has been generated from package.yaml by hpack version 0.14.0.
+-- This file has been generated from package.yaml by hpack version 0.14.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -33,7 +33,7 @@ library
     , containers
     , unordered-containers
     , yaml
-    , aeson >= 0.11
+    , aeson >= 0.8
   exposed-modules:
       Hpack
       Hpack.Config

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,9 @@
-flags: {}
+flags:
+  semigroups:
+    bytestring-builder: false
 packages:
 - '.'
 extra-deps:
-- aeson-0.11.0.0
-resolver: lts-5.3
+- aeson-1.0.0.0
+- semigroups-0.18.2
+resolver: lts-6.14


### PR DESCRIPTION
The cabal file was regenerated by stack and reflects the lower bound for
aeson as given in the package.yaml.