### PR TITLE
Use binary I/O for cabal files

### DIFF
--- a/hpack.cabal
+++ b/hpack.cabal
@@ -1,4 +1,4 @@
--- This file has been generated from package.yaml by hpack version 0.14.1.
+-- This file has been generated from package.yaml by hpack version 0.15.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -28,6 +28,7 @@ library
   build-depends:
       base >= 4.7 && < 5
     , base-compat >= 0.8
+    , bytestring
     , deepseq
     , directory
     , filepath
@@ -59,6 +60,7 @@ executable hpack
   build-depends:
       base >= 4.7 && < 5
     , base-compat >= 0.8
+    , bytestring
     , deepseq
     , directory
     , filepath
@@ -82,6 +84,7 @@ test-suite spec
   build-depends:
       base >= 4.7 && < 5
     , base-compat >= 0.8
+    , bytestring
     , deepseq
     , directory
     , filepath

--- a/package.yaml
+++ b/package.yaml
@@ -13,6 +13,7 @@ ghc-options: -Wall
 dependencies:
   - base >= 4.7 && < 5
   - base-compat >= 0.8
+  - bytestring
   - deepseq
   - directory
   - filepath

--- a/src/Hpack.hs
+++ b/src/Hpack.hs
@@ -20,8 +20,11 @@ import           Prelude.Compat
 import           Control.DeepSeq
 import           Control.Exception
 import           Control.Monad.Compat
+import qualified Data.ByteString as B
 import           Data.List.Compat
 import           Data.Maybe
+import qualified Data.Text as T
+import           Data.Text.Encoding (encodeUtf8)
 import           Data.Version (Version)
 import qualified Data.Version as Version
 import           System.Environment
@@ -120,7 +123,7 @@ hpackWithVersionResult v dir = do
       if (fmap snd old == Just (lines new)) then
         return OutputUnchanged
       else do
-        writeFile cabalFile $ header v ++ new
+        B.writeFile cabalFile $ encodeUtf8 $ T.pack $ header v ++ new
         return Generated
     else
       return AlreadyGeneratedByNewerHpack


### PR DESCRIPTION
This makes character encoding of UTF-8 explicit, and avoids problems
when a different system locale is set. For more information, see:
http://www.snoyman.com/blog/2016/12/beware-of-readfile