### PR TITLE
Allow to "!include" yaml files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 ### Added
 - custom-setup section
   [#148](https://github.com/sol/hpack/pull/148)
+- Support `!include` directives
+  [#144](https://github.com/sol/hpack/pull/144)
 
 ## [0.16.0] - 2017-01-11
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+
 ## [Unreleased]
 ### Added
 - custom-setup section
+  [#148](https://github.com/sol/hpack/pull/148)
+
+## [0.16.0] - 2017-01-11
+### Added
+- Warn when `name` is missing [#109](https://github.com/sol/hpack/issues/109)
+- Support globs in `c-sources`
+  [#123](https://github.com/sol/hpack/pull/123)
+
+### Changed
+- Use binary I/O for cabal files avoiding problems with non-UTF-8 locales
+  [#142](https://github.com/sol/hpack/pull/142)
+  [#143](https://github.com/sol/hpack/pull/143)
+- Fix rendering of `.` as directory (cabal syntax issue)
+  [#125](https://github.com/sol/hpack/pull/125)
+  [#119](https://github.com/sol/hpack/issues/119)
+  [#67](https://github.com/sol/hpack/issues/67)
+
+[Unreleased]: https://github.com/sol/hpack/compare/0.16.0...HEAD
+[0.16.0]: https://github.com/sol/hpack/compare/0.15.0...0.16.0

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ These fields are merged with all library, executable, test, and benchmark compon
 | `ghc-prof-options` | · | | |
 | `cpp-options` | · | | |
 | `cc-options` | · | | |
-| `c-sources` | · | | |
+| `c-sources` | · | | Accepts [glob patterns](#file-globbing) |
 | `extra-lib-dirs` | · | | |
 | `extra-libraries` | · | | |
 | `include-dirs` | · | | |

--- a/README.md
+++ b/README.md
@@ -190,6 +190,10 @@ It is possible to use YAML [anchors][yaml-anchor] (`&`), [aliases][yaml-alias]
 (`*`) and [merge keys][yaml-merge] (`<<`) to define fields and reference them
 later.
 
+[yaml-anchor]: http://yaml.org/spec/1.1/#anchor/syntax
+[yaml-alias]: http://yaml.org/spec/1.1/#alias/syntax
+[yaml-merge]: http://yaml.org/type/merge.html
+
 ```yaml
 executables:
   my-exe-1: &my-exe
@@ -214,9 +218,63 @@ executables:
     ghc-options: *exe-ghc-options
 ```
 
-[yaml-anchor]: http://yaml.org/spec/1.1/#anchor/syntax
-[yaml-alias]: http://yaml.org/spec/1.1/#alias/syntax
-[yaml-merge]: http://yaml.org/type/merge.html
+It is also possible to use the `!include` directive:
+
+```yaml
+# ...
+
+tests:
+  hlint: !include "../common/hlint.yaml"
+```
+
+`hlint.yaml`:
+
+```yaml
+source-dirs: test
+main: hlint.hs
+dependencies: [base, hlint]
+```
+
+This can also be used to provide entire libraries of snippets:
+
+```yaml
+_common/lib: !include "../common/lib.yaml"
+
+name: example1
+version: '0.1.0.0'
+synopsis: Example
+<<: *legal
+
+<<: *defaults
+
+library:
+  source-dirs: src
+
+tests:
+  hlint: *test_hlint
+```
+
+lib.yaml:
+
+```yaml
+- &legal
+  maintainer: Some One <someone@example.com>
+  copyright: (c) 2017 Some One
+  license: BSD3
+
+- &defaults
+  dependencies:
+    - base
+    - containers
+  ghc-options:
+    - -Wall
+    - -Werror
+
+- &test_hlint
+  source-dirs: test
+  main: hlint.hs
+  dependencies: [hlint]
+```
 
 ### Slides
 

--- a/src/Hpack/Yaml.hs
+++ b/src/Hpack/Yaml.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE RecordWildCards #-}
 module Hpack.Yaml where
 
-import           Data.Yaml
+import           Data.Yaml hiding (decodeFile, decodeFileEither)
+import           Data.Yaml.Include
 
 decodeYaml :: FromJSON a => FilePath -> IO (Either String a)
 decodeYaml file = do

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,4 +3,5 @@ packages:
 - '.'
 extra-deps:
 - aeson-0.11.0.0
+- yaml-0.8.21.2
 resolver: lts-5.3


### PR DESCRIPTION
There seems to be little reason not to allow this. Security can hardly be argued here as cabal custom setups and template haskell are far more powerful in this regard.

So anyway, here's an example of usage:

package.yaml:

```yaml
# ...

tests:
    hlint: !include "../common/hlint.yaml"
```

hlint.yaml:

```yaml
source-dirs: test
main: hlint.hs
ghc-options:
    -Wall
    -threaded
    -with-rtsopts=-N
dependencies:
    - base
    - hlint
```

Also, due to how Data.Yaml works, this can be abused to provide entire libraries of snippets:

package.yaml:

```yaml
# if "xxx:" is used instead of a known field, a warning is emitted :-(
name: !include "../common/lib.yaml"

name: example1
version: '0.1.0.0'
synopsis: Example
<<: *legal

<<: *defaults

library:
    source-dirs: src

tests:
    hlint: *test_hlint
```

lib.yaml:

```yaml
- &legal
    maintainer: Some One <someone@example.com>
    copyright: (c) 2017 Some One
    license: BSD3

- &defaults
    dependencies:
        - base
        - containers
    ghc-options:
        - -Wall
        - -Werror

- &test_hlint
    source-dirs: test
    main: hlint.hs
    dependencies: [hlint]
```