### PR TITLE
Silence warnings for unknown top-level fields starting with an underscore

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,40 @@ Glob patterns are expanded according to the following rules:
    separators)
  - `?`, `*` and `**` do not match a `.` at the beginning of a file/directory
 
+### Not repeating yourself
+
+It is possible to use YAML [anchors][yaml-anchor] (`&`), [aliases][yaml-alias]
+(`*`) and [merge keys][yaml-merge] (`<<`) to define fields and reference them
+later.
+
+```yaml
+executables:
+  my-exe-1: &my-exe
+    main: my-exe-1.hs
+    dependencies: [base, my-lib]
+    ghc-options: [-threaded]
+  my-exe-2:
+    <<: *my-exe
+    main: my-exe-2.hs
+```
+
+Warnings for unknown fields will not be emitted for top-level fields starting
+with an underscore, so you can declare global aliases too:
+
+```yaml
+_exe-ghc-options: &exe-ghc-options
+  - -threaded
+  - -rtsopts
+
+executables:
+  my-exe-1:
+    ghc-options: *exe-ghc-options
+```
+
+[yaml-anchor]: http://yaml.org/spec/1.1/#anchor/syntax
+[yaml-alias]: http://yaml.org/spec/1.1/#alias/syntax
+[yaml-merge]: http://yaml.org/type/merge.html
+
 ### Slides
 
  - Slides from my talk about `hpack` at the Singapore Haskell meetup:

--- a/test/Hpack/ConfigSpec.hs
+++ b/test/Hpack/ConfigSpec.hs
@@ -645,6 +645,16 @@ spec = do
         }
         )
 
+    it "allows yaml merging and overriding fields" $ do
+      withPackageConfig_ [i|
+        _common: &common
+          name: n1
+
+        <<: *common
+        name: n2
+        |]
+        (packageName >>> (`shouldBe` "n2"))
+
     context "when reading library section" $ do
       it "warns on unknown fields" $ do
         withPackageWarnings_ [i|

--- a/test/Hpack/ConfigSpec.hs
+++ b/test/Hpack/ConfigSpec.hs
@@ -309,6 +309,7 @@ spec = do
         name: foo
         bar: 23
         baz: 42
+        _qux: 66
         |]
         (`shouldBe` [
           "Ignoring unknown field \"bar\" in package description"
@@ -323,9 +324,11 @@ spec = do
           - condition: impl(ghc)
             bar: 23
             baz: 42
+            _qux: 66
         |]
         (`shouldBe` [
-          "Ignoring unknown field \"bar\" in package description"
+          "Ignoring unknown field \"_qux\" in package description"
+        , "Ignoring unknown field \"bar\" in package description"
         , "Ignoring unknown field \"baz\" in package description"
         ]
         )


### PR DESCRIPTION
This lets users declare standalone YAML anchors and reuse them using YAML
aliases later:

```yaml
_: &mydeps
 - base
 - containers
```

```yaml
_my_library_of_hpack_stuff:
 - &mydeps [base, containers]
 - &myflags [-threaded, -Wall]
```

Also, this pull request adds a test that field overriding works as
expected and extends the README with a section on not repeating
yourself using these YAML tricks.

See also #144, which is a followup (logically, but not chronologically)
to this and enables putting those _libraries_of_hpack_stuff to separate
files and including them in multiple package.yamls across a larger
codebase.