### PR TITLE
Add setup-depends

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,17 +35,23 @@ existing cabal file into a `package.yaml`.
 | `license` | `license` | | | |
 | `license-file` | `license-file` | `LICENSE` if file exists | | |
 | `tested-with` | `tested-with` | | | |
-| `build-type` | `build-type` | `Simple` | Must be `Simple`, `Configure`, `Make`, or `Custom` | |
+| `build-type` | `build-type` | `Simple`, or `Custom` if `custom-setup` section exists | Must be `Simple`, `Configure`, `Make`, or `Custom` | |
 | | `cabal-version` | `>= 1.10` or `>= 1.21` | `>= 1.21` if library component has `reexported-modules` field | |
 | `extra-source-files` | `extra-source-files` | | Accepts [glob patterns](#file-globbing) | |
 | `data-files` | `data-files` | | Accepts [glob patterns](#file-globbing) | |
 | `github` | `source-repository head` | | Accepts `user/repo` or `user/repo/subdir` | `github: foo/bar`
 | `git`    | `source-repository head` | | No effect if `github` given | `git: https://my.repo.com/foo` |
+| `custom-setup` | `custom-setup` | | See [Custom setup](#custom-setup) | |
 | `flags`  | `flag <name>` | | Map from flag name to flag (see [Flags](#flags)) | |
 | `library` | `library` | | See [Library fields](#library-fields) | |
 | `executables` | `executable <name>` | | Map from executable name to executable (see [Executable fields](#executable-fields)) | |
 | `tests` | `test-suite <name>` | | Map from test name to test (see [Test fields](#test-fields)) | |
 | `benchmarks` | `benchmark <name>` | | Map from benchmark name to benchmark (see [Benchmark fields](#benchmark-fields)) | |
+
+#### <a name="custom-setup"></a>Custom setup
+
+| Hpack | Cabal | Default | Notes | Example |
+| `dependencies` | `setup-depends` | --- | Existence implies `build-type: Custom` | --- |
 
 #### Global top-level fields
 

--- a/hpack.cabal
+++ b/hpack.cabal
@@ -78,7 +78,7 @@ test-suite spec
   main-is: Spec.hs
   hs-source-dirs:
       test
-      src
+    , src
   ghc-options: -Wall
   cpp-options: -DTEST
   build-depends:

--- a/src/Hpack/Run.hs
+++ b/src/Hpack/Run.hs
@@ -68,8 +68,13 @@ renderPackage settings alignment existingFieldOrder sectionsFieldOrder Package{.
     dataFiles :: Element
     dataFiles = Field "data-files" (LineSeparatedList packageDataFiles)
 
+    sourceRepository :: [Element]
     sourceRepository = maybe [] (return . renderSourceRepository) packageSourceRepository
 
+    customSetup :: [Element]
+    customSetup = maybe [] (return . renderCustomSetup) packageCustomSetup
+
+    library :: [Element]
     library = maybe [] (return . renderLibrary) packageLibrary
 
     stanzas :: [Element]
@@ -78,7 +83,8 @@ renderPackage settings alignment existingFieldOrder sectionsFieldOrder Package{.
       : dataFiles
       : sourceRepository
       ++ concat [
-        map renderFlag packageFlags
+        customSetup
+      , map renderFlag packageFlags
       , library
       , renderExecutables packageExecutables
       , renderTests packageTests
@@ -189,6 +195,10 @@ renderExecutableSection sect@(sectionData -> Executable{..}) =
     mainIs = Field "main-is" (Literal executableMain)
     otherModules = renderOtherModules executableOtherModules
 
+renderCustomSetup :: CustomSetup -> Element
+renderCustomSetup CustomSetup{..} =
+  Stanza "custom-setup" [renderSetupDepends customSetupDependencies]
+
 renderLibrary :: Section Library -> Element
 renderLibrary sect@(sectionData -> Library{..}) = Stanza "library" $
   renderSection sect ++
@@ -279,3 +289,6 @@ renderOtherExtensions = Field "other-extensions" . WordList
 
 renderBuildTools :: [Dependency] -> Element
 renderBuildTools = Field "build-tools" . CommaSeparatedList . map dependencyName
+
+renderSetupDepends :: [Dependency] -> Element
+renderSetupDepends = Field "setup-depends" . CommaSeparatedList . map dependencyName

--- a/test/Hpack/ConfigSpec.hs
+++ b/test/Hpack/ConfigSpec.hs
@@ -645,6 +645,46 @@ spec = do
         }
         )
 
+    context "when reading custom-setup section" $ do
+      it "warns on unknown fields" $ do
+        withPackageWarnings_ [i|
+          name: foo
+          custom-setup:
+            foo: 1
+            bar: 2
+          |]
+          (`shouldBe` [
+            "Ignoring unknown field \"bar\" in custom-setup section"
+          , "Ignoring unknown field \"foo\" in custom-setup section"
+          ])
+
+      it "sets build-type: Custom, if missing" $ do
+        withPackageConfig_ [i|
+          custom-setup:
+            dependencies:
+              - base
+          |]
+          (packageBuildType >>> (`shouldBe` Custom))
+
+      it "leaves build-type alone, if it exists" $ do
+        withPackageConfig_ [i|
+          name: foo
+          build-type: Make
+          custom-setup:
+            dependencies:
+              - base
+          |]
+          (packageBuildType >>> (`shouldBe` Make))
+
+      it "accepts dependencies" $ do
+        withPackageConfig_ [i|
+          custom-setup:
+            dependencies:
+              - foo >1.0
+              - bar ==2.0
+          |]
+          (packageCustomSetup >>> fmap customSetupDependencies >>> (`shouldBe` Just ["foo >1.0", "bar ==2.0"]))
+
     it "allows yaml merging and overriding fields" $ do
       withPackageConfig_ [i|
         _common: &common

--- a/test/Hpack/RunSpec.hs
+++ b/test/Hpack/RunSpec.hs
@@ -103,6 +103,22 @@ spec = do
         , "  default-language: Haskell2010"
         ]
 
+    context "when rendering custom-setup section" $ do
+      it "includes setup-depends" $ do
+        let setup = CustomSetup
+              { customSetupDependencies = ["foo >1.0", "bar ==2.0"] }
+        renderPackage_ package {packageCustomSetup = Just setup} `shouldBe` unlines [
+            "name: foo"
+          , "version: 0.0.0"
+          , "build-type: Simple"
+          , "cabal-version: >= 1.10"
+          , ""
+          , "custom-setup"
+          , "  setup-depends:"
+          , "      foo >1.0"
+          , "    , bar ==2.0"
+          ]
+
     context "when rendering library section" $ do
       it "renders library section" $ do
         renderPackage_ package {packageLibrary = Just $ section library} `shouldBe` unlines [


### PR DESCRIPTION
Addresses #147 

I did this rather quickly, please let me know if you see any problems.

Couple notes...

1. `setup-depends` is the only field inside a `custom-setup` stanza (currently), so I just made it a top-level field. Should it go inside a `custom-setup` stanza a la cabal instead?
2. I'm not sure if having a `setup-depends` implies `build-type: Custom` or not.