### PR TITLE
Add shortcut executable section

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ existing cabal file into a `package.yaml`.
 | `flags`  | `flag <name>` | | Map from flag name to flag (see [Flags](#flags)) | |
 | `library` | · | | See [Library fields](#library-fields) | |
 | `executables` | `executable <name>` | | Map from executable name to executable (see [Executable fields](#executable-fields)) | |
+| `executable` | `executable <package-name>` | | Shortcut for `executables: { package-name: ... }` | |
 | `tests` | `test-suite <name>` | | Map from test name to test (see [Test fields](#test-fields)) | |
 | `benchmarks` | `benchmark <name>` | | Map from benchmark name to benchmark (see [Benchmark fields](#benchmark-fields)) | |
 

--- a/src/Hpack/Config.hs
+++ b/src/Hpack/Config.hs
@@ -523,16 +523,15 @@ mkPackage dir (CaptureUnknownFields unknownFields globalOptions@Section{sectionD
   let
     executableWarnings :: [String]
     executableSections :: [(String, CaptureUnknownFields (Section ExecutableSection))]
-    (executableWarnings, executableSections) = case packageConfigExecutable of
-      Nothing -> ([], toList packageConfigExecutables)
-      Just executable -> case packageConfigExecutables of
-        Nothing -> ([], [(packageName_, executable)])
-        Just executables -> case Map.insertLookupWithKey (\_ x _ -> x) packageName_ executable executables of
-          (Nothing, m) -> ([], Map.toList m)
-          (Just _, m) ->
-            ( ["Ignoring field " ++ show packageName_ ++ " in executables section in favor of implicit \"executable\" section"]
-            , Map.toList m
-            )
+    (executableWarnings, executableSections) =
+      case (packageConfigExecutable, packageConfigExecutables) of
+        (Nothing, Nothing) -> ([], [])
+        (Just executable, Nothing) -> ([], [(packageName_, executable)])
+        (Nothing, Just executables) -> ([], Map.toList executables)
+        (Just _, Just executables) ->
+          ( ["Ignoring executable section because executables section exists"]
+          , Map.toList executables
+          )
 
     mLibrary :: Maybe (Section Library)
     mLibrary = fmap snd libraryResult

--- a/src/Hpack/Config.hs
+++ b/src/Hpack/Config.hs
@@ -599,8 +599,8 @@ mkPackage dir (CaptureUnknownFields unknownFields globalOptions@Section{sectionD
         ++ flagWarnings
         ++ maybe [] (formatUnknownFields "custom-setup section") (captureUnknownFieldsFields <$> packageConfigCustomSetup)
         ++ maybe [] (formatUnknownFields "library section") (captureUnknownFieldsFields <$> packageConfigLibrary)
-        ++ formatUnknownSectionFields "executable" executableSections
-        ++ formatUnknownSectionFields "test" testsSections
+        ++ formatUnknownSectionFields (isJust packageConfigExecutables) "executable" executableSections
+        ++ formatUnknownSectionFields True "test" testsSections
         ++ formatMissingSourceDirs missingSourceDirs
         ++ libraryWarnings
         ++ executableWarnings
@@ -651,11 +651,13 @@ mkPackage dir (CaptureUnknownFields unknownFields globalOptions@Section{sectionD
       where
         f field = "Ignoring unknown field " ++ show field ++ " in " ++ name
 
-    formatUnknownSectionFields :: String -> [(String, CaptureUnknownFields a)] -> [String]
-    formatUnknownSectionFields sectionType = concatMap f . map (fmap captureUnknownFieldsFields)
+    formatUnknownSectionFields :: Bool -> String -> [(String, CaptureUnknownFields a)] -> [String]
+    formatUnknownSectionFields showSect sectionType = concatMap f . map (fmap captureUnknownFieldsFields)
       where
         f :: (String, [String]) -> [String]
-        f (sect, fields) = formatUnknownFields (sectionType ++ " section " ++ show sect) fields
+        f (sect, fields) = formatUnknownFields
+          (sectionType ++ " section" ++ if showSect then " " ++ show sect else "")
+          fields
 
     formatMissingSourceDirs = map f
       where

--- a/src/Hpack/Config.hs
+++ b/src/Hpack/Config.hs
@@ -333,6 +333,7 @@ data PackageConfig = PackageConfig {
 , packageConfigGit :: Maybe String
 , packageConfigCustomSetup :: Maybe (CaptureUnknownFields CustomSetupSection)
 , packageConfigLibrary :: Maybe (CaptureUnknownFields (Section LibrarySection))
+, packageConfigExecutable :: Maybe (CaptureUnknownFields (Section ExecutableSection))
 , packageConfigExecutables :: Maybe (Map String (CaptureUnknownFields (Section ExecutableSection)))
 , packageConfigTests :: Maybe (Map String (CaptureUnknownFields (Section ExecutableSection)))
 , packageConfigBenchmarks :: Maybe (Map String (CaptureUnknownFields (Section ExecutableSection)))
@@ -527,6 +528,13 @@ mkPackage dir (CaptureUnknownFields unknownFields globalOptions@Section{sectionD
     mCustomSetup :: Maybe CustomSetup
     mCustomSetup = toCustomSetup <$> mCustomSetupSection
 
+    executableSections :: [(String, CaptureUnknownFields (Section ExecutableSection))]
+    executableSections = toList $ case packageConfigExecutable of
+      Nothing -> packageConfigExecutables
+      Just executable -> Just $ case packageConfigExecutables of
+        Nothing -> Map.singleton name executable
+        Just executables -> Map.insert name executable executables
+
   libraryResult <- mapM (toLibrary dir name globalOptions) mLibrarySection
   let
     mLibrary :: Maybe (Section Library)
@@ -607,9 +615,6 @@ mkPackage dir (CaptureUnknownFields unknownFields globalOptions@Section{sectionD
 
   return (warnings, pkg)
   where
-    executableSections :: [(String, CaptureUnknownFields (Section ExecutableSection))]
-    executableSections = toList packageConfigExecutables
-
     testsSections :: [(String, CaptureUnknownFields (Section ExecutableSection))]
     testsSections = toList packageConfigTests
 

--- a/test/Hpack/ConfigSpec.hs
+++ b/test/Hpack/ConfigSpec.hs
@@ -945,6 +945,15 @@ spec = do
           |]
           (packageExecutables >>> (`shouldBe` [section $ executable "foo" "driver/Main.hs"]))
 
+      it "warns on unknown executable fields" $ do
+        withPackageWarnings_ [i|
+          name: foo
+          executable:
+            main: Main.hs
+            unknown: true
+          |]
+          (`shouldBe` ["Ignoring unknown field \"unknown\" in executable section \"foo\""])
+
       it "prefers executable to executables section" $ do
         withPackageConfig_ [i|
           executable:

--- a/test/Hpack/ConfigSpec.hs
+++ b/test/Hpack/ConfigSpec.hs
@@ -954,28 +954,7 @@ spec = do
           |]
           (`shouldBe` ["Ignoring unknown field \"unknown\" in executable section \"foo\""])
 
-      it "prefers executable to executables section" $ do
-        withPackageConfig_ [i|
-          executable:
-            main: driver/Main1.hs
-          executables:
-            foo:
-              main: driver/Main2.hs
-          |]
-          (packageExecutables >>> (`shouldBe` [section $ executable "foo" "driver/Main1.hs"]))
-
-      it "warns when executable section clobbers executables" $ do
-        withPackageWarnings_ [i|
-          name: foo
-          executable:
-            main: driver/Main1.hs
-          executables:
-            foo:
-              main: driver/Main2.hs
-          |]
-          (`shouldBe` ["Ignoring field \"foo\" in executables section in favor of implicit \"executable\" section"])
-
-      it "allows both executable and executables sections" $ do
+      it "ignoes executable section if executables section exists" $ do
         withPackageConfig_ [i|
           executable:
             main: driver/Main1.hs
@@ -983,7 +962,18 @@ spec = do
             foo2:
               main: driver/Main2.hs
           |]
-          (packageExecutables >>> (`shouldBe` [section $ executable "foo" "driver/Main1.hs", section $ executable "foo2" "driver/Main2.hs"]))
+          (packageExecutables >>> (`shouldBe` [section $ executable "foo2" "driver/Main2.hs"]))
+
+      it "warns with both executable and executables sections" $ do
+        withPackageWarnings_ [i|
+          name: foo
+          executable:
+            main: driver/Main1.hs
+          executables:
+            foo2:
+              main: driver/Main2.hs
+          |]
+          (`shouldBe` ["Ignoring executable section because executables section exists"])
 
       it "accepts arbitrary entry points as main" $ do
         withPackageConfig_ [i|

--- a/test/Hpack/ConfigSpec.hs
+++ b/test/Hpack/ConfigSpec.hs
@@ -952,7 +952,7 @@ spec = do
             main: Main.hs
             unknown: true
           |]
-          (`shouldBe` ["Ignoring unknown field \"unknown\" in executable section \"foo\""])
+          (`shouldBe` ["Ignoring unknown field \"unknown\" in executable section"])
 
       it "ignoes executable section if executables section exists" $ do
         withPackageConfig_ [i|

--- a/test/Hpack/ConfigSpec.hs
+++ b/test/Hpack/ConfigSpec.hs
@@ -930,13 +930,40 @@ spec = do
           ]
           )
 
-      it "reads executable section" $ do
+      it "reads executables section" $ do
         withPackageConfig_ [i|
           executables:
             foo:
               main: driver/Main.hs
           |]
           (packageExecutables >>> (`shouldBe` [section $ executable "foo" "driver/Main.hs"]))
+
+      it "reads executable section" $ do
+        withPackageConfig_ [i|
+          executable:
+            main: driver/Main.hs
+          |]
+          (packageExecutables >>> (`shouldBe` [section $ executable "foo" "driver/Main.hs"]))
+
+      it "prefers executable to executables section" $ do
+        withPackageConfig_ [i|
+          executable:
+            main: driver/Main1.hs
+          executables:
+            foo:
+              main: driver/Main2.hs
+          |]
+          (packageExecutables >>> (`shouldBe` [section $ executable "foo" "driver/Main1.hs"]))
+
+      it "allows both executable and executables sections" $ do
+        withPackageConfig_ [i|
+          executable:
+            main: driver/Main1.hs
+          executables:
+            foo2:
+              main: driver/Main2.hs
+          |]
+          (packageExecutables >>> (`shouldBe` [section $ executable "foo" "driver/Main1.hs", section $ executable "foo2" "driver/Main2.hs"]))
 
       it "accepts arbitrary entry points as main" $ do
         withPackageConfig_ [i|

--- a/test/Hpack/ConfigSpec.hs
+++ b/test/Hpack/ConfigSpec.hs
@@ -955,6 +955,17 @@ spec = do
           |]
           (packageExecutables >>> (`shouldBe` [section $ executable "foo" "driver/Main1.hs"]))
 
+      it "warns when executable section clobbers executables" $ do
+        withPackageWarnings_ [i|
+          name: foo
+          executable:
+            main: driver/Main1.hs
+          executables:
+            foo:
+              main: driver/Main2.hs
+          |]
+          (`shouldBe` ["Ignoring field \"foo\" in executables section in favor of implicit \"executable\" section"])
+
       it "allows both executable and executables sections" $ do
         withPackageConfig_ [i|
           executable:


### PR DESCRIPTION
This fixes #161. It adds a new `executable` section that can be used in addition to or alongside the old `executables` section. This new section allows you to simplify executable definition from this:

``` yaml
name: example
executables:
  example: { ... }
```

To this:

``` yaml
name: example
executable: { ... }
```

That is, it defines a new executable and uses the package name as the name of the executable. 

If you define an `executable` section, you can still define an `executables` section (and vice versa). For example:

``` yaml
name: example
executable: { ... }
executables:
  example-extra: { ... }
```

If you define both sections and one of the `executables` has the same name as the package, it will be silently discarded in favor of the `executable` section. For instance:

``` yaml
name: example
executable: { ... } # this one wins
executables:
  example: { ... } # this one loses
```

This is a little surprising. I would prefer to make it either a warning or an error, but I wanted to make sure I'm barking up the right tree with this pull request before I spend more time on it 😄