### PR TITLE
Propagate section-specific data in conditionals.

### DIFF
--- a/src/Hpack/Config.hs
+++ b/src/Hpack/Config.hs
@@ -524,7 +524,7 @@ instance Functor Conditional where
     where
     condMap s = s { sectionConditionals = (fmap . fmap) f (sectionConditionals s) }
 
-instance (HasFieldNames a, HasFieldNames b) => HasFieldNames (Section b a) where
+instance HasFieldNames a => HasFieldNames (Section b a) where
   fieldNames Proxy = fieldNames (Proxy :: Proxy a) ++ fieldNames (Proxy :: Proxy (CommonOptions a))
   ignoreUnderscoredUnknownFields _ = ignoreUnderscoredUnknownFields (Proxy :: Proxy a)
 

--- a/src/Hpack/Config.hs
+++ b/src/Hpack/Config.hs
@@ -524,7 +524,7 @@ instance Functor Conditional where
     where
     condMap s = s { sectionConditionals = (fmap . fmap) f (sectionConditionals s) }
 
-instance (HasFieldNames a, HasFieldNames b) => HasFieldNames (Section a b) where
+instance (HasFieldNames a, HasFieldNames b) => HasFieldNames (Section b a) where
   fieldNames Proxy = fieldNames (Proxy :: Proxy a) ++ fieldNames (Proxy :: Proxy (CommonOptions a))
   ignoreUnderscoredUnknownFields _ = ignoreUnderscoredUnknownFields (Proxy :: Proxy a)
 

--- a/src/Hpack/Run.hs
+++ b/src/Hpack/Run.hs
@@ -12,7 +12,9 @@ module Hpack.Run (
 , defaultRenderSettings
 #ifdef TEST
 , renderConditional
+, renderExecutableSectionBody
 , renderFlag
+, renderLibraryBody
 , renderSection
 , renderSourceRepository
 , renderDirectories
@@ -247,9 +249,9 @@ renderSection renderAll Section{..} = [
 renderConditional :: (Section a a -> [Element]) -> Conditional a -> Element
 renderConditional renderBody (Conditional condition sect mElse) = case mElse of
   Nothing -> if_
-  Just else_ -> Group if_ (Stanza "else" $ renderSection renderBody else_)
+  Just else_ -> Group if_ (Stanza "else" $ renderBody else_)
   where
-    if_ = Stanza ("if " ++ condition) (renderSection renderBody sect)
+    if_ = Stanza ("if " ++ condition) (renderBody sect)
 
 defaultLanguage :: Element
 defaultLanguage = Field "default-language" "Haskell2010"

--- a/test/Hpack/ConfigSpec.hs
+++ b/test/Hpack/ConfigSpec.hs
@@ -26,7 +26,7 @@ package :: Package
 package = Config.package "foo" "0.0.0"
 
 executable :: String -> String -> Executable
-executable name main_ = Executable name main_ []
+executable name main_ = Executable (Just name) (Just main_) []
 
 library :: Library
 library = Library Nothing [] ["Paths_foo"] []
@@ -152,7 +152,7 @@ spec = do
                 |]
               conditionals = [
                 Conditional "os(windows)"
-                (section ()){sectionDependencies = ["Win32"]}
+                (section Empty){sectionDependencies = ["Win32"]}
                 Nothing
                 ]
           captureUnknownFieldsValue <$> decodeEither input
@@ -170,7 +170,7 @@ spec = do
                   - condition: os(windows)
                     baz: 23
                 |]
-          captureUnknownFieldsFields <$> (decodeEither input :: Either String (CaptureUnknownFields (Section Empty)))
+          captureUnknownFieldsFields <$> (decodeEither input :: Either String (CaptureUnknownFields (Section Empty Empty)))
             `shouldBe` Right ["foo", "bar", "bar2", "baz"]
 
         context "when parsing conditionals with else-branch" $ do
@@ -185,10 +185,10 @@ spec = do
                   |]
                 conditionals = [
                   Conditional "os(windows)"
-                  (section ()){sectionDependencies = ["Win32"]}
-                  (Just (section ()){sectionDependencies = ["unix"]})
+                  (section Empty){sectionDependencies = ["Win32"]}
+                  (Just (section Empty){sectionDependencies = ["unix"]})
                   ]
-                r :: Either String (Section Empty)
+                r :: Either String (Section Empty Empty)
                 r = captureUnknownFieldsValue <$> decodeEither input
             sectionConditionals <$> r `shouldBe` Right conditionals
 
@@ -201,7 +201,7 @@ spec = do
                     else: null
                   |]
 
-                r :: Either String (Section Empty)
+                r :: Either String (Section Empty Empty)
                 r = captureUnknownFieldsValue <$> decodeEither input
             sectionConditionals <$> r `shouldSatisfy` isLeft
 
@@ -215,7 +215,7 @@ spec = do
                     else:
                       baz: null
                   |]
-            captureUnknownFieldsFields <$> (decodeEither input :: Either String (CaptureUnknownFields (Section Empty)))
+            captureUnknownFieldsFields <$> (decodeEither input :: Either String (CaptureUnknownFields (Section Empty Empty)))
               `shouldBe` Right ["foo", "bar", "baz"]
 
     context "when parsing a Dependency" $ do

--- a/test/Hpack/RunSpec.hs
+++ b/test/Hpack/RunSpec.hs
@@ -301,6 +301,22 @@ spec = do
         , "        Win32"
         ]
 
+    it "renders library-specific property in conditional" $ do
+      let conditional = Conditional "os(windows)" (section library{libraryExposedModules=["Foo"]}) Nothing
+      render defaultRenderSettings 0 (renderConditional renderLibraryBody conditional) `shouldBe` [
+          "if os(windows)"
+        , "  exposed-modules:"
+        , "      Foo"
+        ]
+
+    it "renders executable-specific property in conditional" $ do
+      let conditional = Conditional "os(windows)" (section $ Executable Nothing Nothing ["Foo"]) Nothing
+      render defaultRenderSettings 0 (renderConditional renderExecutableSectionBody conditional) `shouldBe` [
+          "if os(windows)"
+        , "  other-modules:"
+        , "      Foo"
+        ]
+
   describe "renderFlag" $ do
     it "renders flags" $ do
       let flag = (Flag "foo" (Just "some flag") True False)

--- a/test/Hpack/RunSpec.hs
+++ b/test/Hpack/RunSpec.hs
@@ -12,6 +12,9 @@ import           Hpack.Run
 library :: Library
 library = Library Nothing [] [] []
 
+renderEmptySection :: Section Empty Empty -> [Element]
+renderEmptySection = renderSection renderEmptySection
+
 spec :: Spec
 spec = do
   describe "renderPackage" $ do
@@ -269,16 +272,16 @@ spec = do
 
   describe "renderConditional" $ do
     it "renders conditionals" $ do
-      let conditional = Conditional "os(windows)" (section ()) {sectionDependencies = ["Win32"]} Nothing
-      render defaultRenderSettings 0 (renderConditional conditional) `shouldBe` [
+      let conditional = Conditional "os(windows)" (section Empty) {sectionDependencies = ["Win32"]} Nothing
+      render defaultRenderSettings 0 (renderConditional renderEmptySection conditional) `shouldBe` [
           "if os(windows)"
         , "  build-depends:"
         , "      Win32"
         ]
 
     it "renders conditionals with else-branch" $ do
-      let conditional = Conditional "os(windows)" (section ()) {sectionDependencies = ["Win32"]} (Just $ (section ()) {sectionDependencies = ["unix"]})
-      render defaultRenderSettings 0 (renderConditional conditional) `shouldBe` [
+      let conditional = Conditional "os(windows)" (section Empty) {sectionDependencies = ["Win32"]} (Just $ (section Empty) {sectionDependencies = ["unix"]})
+      render defaultRenderSettings 0 (renderConditional renderEmptySection conditional) `shouldBe` [
           "if os(windows)"
         , "  build-depends:"
         , "      Win32"
@@ -288,9 +291,9 @@ spec = do
         ]
 
     it "renders nested conditionals" $ do
-      let conditional = Conditional "arch(i386)" (section ()) {sectionGhcOptions = ["-threaded"], sectionConditionals = [innerConditional]} Nothing
-          innerConditional = Conditional "os(windows)" (section ()) {sectionDependencies = ["Win32"]} Nothing
-      render defaultRenderSettings 0 (renderConditional conditional) `shouldBe` [
+      let conditional = Conditional "arch(i386)" (section Empty) {sectionGhcOptions = ["-threaded"], sectionConditionals = [innerConditional]} Nothing
+          innerConditional = Conditional "os(windows)" (section Empty) {sectionDependencies = ["Win32"]} Nothing
+      render defaultRenderSettings 0 (renderConditional renderEmptySection conditional) `shouldBe` [
           "if arch(i386)"
         , "  ghc-options: -threaded"
         , "  if os(windows)"


### PR DESCRIPTION
This is a working approach to allowing section-specific properties in conditionals.

The main goal is to allow library-specific properties in the body of conditionals. For example:
```
library:
  source-dirs: src
  exposed-modules: Foo
  other-modules: []
  when:
    condition: os(windows)
    exposed-modules:
    - Bar
```

Implementation details:

Effectively I propagated the type parameter for a `Section` throughout all of the conditional-related code.

This changes the existing behavior in a few instances.
* You can now specific properties like `github` within a conditional for the package (top-level properties). One previous test assumed that was invalid, and I changed the test to allow that case.
* Package-specific properties within conditionals allow underscore prefixes, because all package-specific do. It is less work to leave it like this. Note that it does require a change to a test which assumed that wasn't allowed before.
* `executableSectionMain` in `ExecutableSection` now needs to be `Maybe FilePath` instead of `FilePath`. This is so that you don't have to specify `main` in every conditional in an executable section (which would break existing code). Note that this pushes the validation that `main` is supplied to a different area in the codebase. The new validation code works but could be improved.

I added a `FlatThen` as an analogous type to `ThenElse` which handles parsing the flat `condition` property with its sibling section properties.

Note of caution: it is recommended to always set `other-modules` (and `exposed-modules` in the `library` section) at the root level when using one or both properties within a conditional. Else the recursive file selection behavior will likely conflict with what the conditional is trying to achieve. Note that in the code, the conditionals do not expand empty `exposed-modules` and `other-modules`. That is only done at the first level of the `library` and executable sections.
