### PR TITLE
Allow specifying dependencies as a hash

### DIFF
--- a/hpack.cabal
+++ b/hpack.cabal
@@ -1,4 +1,4 @@
--- This file has been generated from package.yaml by hpack version 0.18.0.
+-- This file has been generated from package.yaml by hpack version 0.18.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -39,6 +39,7 @@ library
     , unordered-containers
     , yaml
     , aeson >= 0.11
+    , vector
   exposed-modules:
       Hpack
       Hpack.Config
@@ -72,6 +73,7 @@ executable hpack
     , unordered-containers
     , yaml
     , aeson >= 0.11
+    , vector
     , hpack
   default-language: Haskell2010
 
@@ -96,6 +98,7 @@ test-suite spec
     , unordered-containers
     , yaml
     , aeson >= 0.11
+    , vector
     , hspec == 2.*
     , QuickCheck
     , temporary

--- a/package.yaml
+++ b/package.yaml
@@ -24,6 +24,7 @@ dependencies:
   - unordered-containers
   - yaml
   - aeson >= 0.11
+  - vector
 
 library:
   source-dirs: src

--- a/src/Hpack/Config.hs
+++ b/src/Hpack/Config.hs
@@ -388,7 +388,7 @@ instance FromJSON Dependencies where
         Null -> pure (Dependency (T.unpack k) Nothing)
         Object _ -> Dependency <$> pure (T.unpack k) <*> (Just <$> parseJSON v')
         String s -> pure (Dependency (unwords (map T.unpack [k, s])) Nothing)
-        _ -> typeMismatch "Object or String" v')
+        _ -> typeMismatch "Null, Object, or String" v')
       (HashMap.toList o)
     String s -> pure (Dependencies [fromString (T.unpack s)])
     _ -> typeMismatch "Array, Object, or String" v

--- a/src/Hpack/Run.hs
+++ b/src/Hpack/Run.hs
@@ -265,8 +265,8 @@ renderOtherModules = Field "other-modules" . LineSeparatedList
 renderReexportedModules :: [String] -> Element
 renderReexportedModules = Field "reexported-modules" . LineSeparatedList
 
-renderDependencies :: [Dependency] -> Element
-renderDependencies = Field "build-depends" . CommaSeparatedList . map dependencyName
+renderDependencies :: Dependencies -> Element
+renderDependencies = Field "build-depends" . CommaSeparatedList . map dependencyName . dependenciesValue
 
 renderGhcOptions :: [GhcOption] -> Element
 renderGhcOptions = Field "ghc-options" . WordList
@@ -295,8 +295,8 @@ renderDefaultExtensions = Field "default-extensions" . WordList
 renderOtherExtensions :: [String] -> Element
 renderOtherExtensions = Field "other-extensions" . WordList
 
-renderBuildTools :: [Dependency] -> Element
-renderBuildTools = Field "build-tools" . CommaSeparatedList . map dependencyName
+renderBuildTools :: Dependencies -> Element
+renderBuildTools = Field "build-tools" . CommaSeparatedList . map dependencyName . dependenciesValue
 
-renderSetupDepends :: [Dependency] -> Element
-renderSetupDepends = Field "setup-depends" . CommaSeparatedList . map dependencyName
+renderSetupDepends :: Dependencies -> Element
+renderSetupDepends = Field "setup-depends" . CommaSeparatedList . map dependencyName . dependenciesValue

--- a/test/Hpack/ConfigSpec.hs
+++ b/test/Hpack/ConfigSpec.hs
@@ -59,11 +59,11 @@ spec = do
       renamePackage "bar" package `shouldBe` package {packageName = "bar"}
 
     it "renames dependencies on self" $ do
-      let packageWithExecutable dependencies = package {packageExecutables = [(section $ executable "main" "Main.hs") {sectionDependencies = dependencies}]}
+      let packageWithExecutable dependencies = package {packageExecutables = [(section $ executable "main" "Main.hs") {sectionDependencies = Dependencies dependencies}]}
       renamePackage "bar" (packageWithExecutable ["foo"]) `shouldBe` (packageWithExecutable ["bar"]) {packageName = "bar"}
 
   describe "renameDependencies" $ do
-    let sectionWithDeps dependencies = (section ()) {sectionDependencies = dependencies}
+    let sectionWithDeps dependencies = (section ()) {sectionDependencies = Dependencies dependencies}
 
     it "renames dependencies" $ do
       renameDependencies "bar" "baz" (sectionWithDeps ["foo", "bar"]) `shouldBe` sectionWithDeps ["foo", "baz"]
@@ -87,7 +87,7 @@ spec = do
               dependencies: hpack
               |]
         captureUnknownFieldsValue <$> decodeEither input
-          `shouldBe` Right (section Empty){sectionDependencies = ["hpack"]}
+          `shouldBe` Right (section Empty){sectionDependencies = Dependencies ["hpack"]}
 
       it "accepts includes-dirs" $ do
         let input = [i|
@@ -152,7 +152,7 @@ spec = do
                 |]
               conditionals = [
                 Conditional "os(windows)"
-                (section ()){sectionDependencies = ["Win32"]}
+                (section ()){sectionDependencies = Dependencies ["Win32"]}
                 Nothing
                 ]
           captureUnknownFieldsValue <$> decodeEither input
@@ -185,8 +185,8 @@ spec = do
                   |]
                 conditionals = [
                   Conditional "os(windows)"
-                  (section ()){sectionDependencies = ["Win32"]}
-                  (Just (section ()){sectionDependencies = ["unix"]})
+                  (section ()){sectionDependencies = Dependencies ["Win32"]}
+                  (Just (section ()){sectionDependencies = Dependencies ["unix"]})
                   ]
                 r :: Either String (Section Empty)
                 r = captureUnknownFieldsValue <$> decodeEither input
@@ -724,7 +724,7 @@ spec = do
               - foo >1.0
               - bar ==2.0
           |]
-          (packageCustomSetup >>> fmap customSetupDependencies >>> (`shouldBe` Just ["foo >1.0", "bar ==2.0"]))
+          (packageCustomSetup >>> fmap customSetupDependencies >>> (`shouldBe` Just (Dependencies ["foo >1.0", "bar ==2.0"])))
 
     it "allows yaml merging and overriding fields" $ do
       withPackageConfig_ [i|
@@ -766,7 +766,7 @@ spec = do
               - alex
               - happy
           |]
-          (packageLibrary >>> (`shouldBe` Just (section library) {sectionBuildTools = ["alex", "happy"]}))
+          (packageLibrary >>> (`shouldBe` Just (section library) {sectionBuildTools = Dependencies ["alex", "happy"]}))
 
       it "accepts default-extensions" $ do
         withPackageConfig_ [i|
@@ -802,7 +802,7 @@ spec = do
             - happy
           library: {}
           |]
-          (packageLibrary >>> (`shouldBe` Just (section library) {sectionBuildTools = ["alex", "happy"]}))
+          (packageLibrary >>> (`shouldBe` Just (section library) {sectionBuildTools = Dependencies ["alex", "happy"]}))
 
       it "accepts c-sources" $ do
         withPackageConfig [i|
@@ -1007,7 +1007,7 @@ spec = do
                 - alex
                 - happy
           |]
-          (packageExecutables >>> (`shouldBe` [(section $ executable "foo" "Main.hs") {sectionBuildTools = ["alex", "happy"]}]))
+          (packageExecutables >>> (`shouldBe` [(section $ executable "foo" "Main.hs") {sectionBuildTools = Dependencies ["alex", "happy"]}]))
 
       it "accepts global source-dirs" $ do
         withPackageConfig_ [i|
@@ -1029,7 +1029,7 @@ spec = do
             foo:
               main: Main.hs
           |]
-          (packageExecutables >>> (`shouldBe` [(section $ executable "foo" "Main.hs") {sectionBuildTools = ["alex", "happy"]}]))
+          (packageExecutables >>> (`shouldBe` [(section $ executable "foo" "Main.hs") {sectionBuildTools = Dependencies ["alex", "happy"]}]))
 
       it "infers other-modules" $ do
         withPackageConfig [i|
@@ -1219,7 +1219,7 @@ spec = do
               main: test/Spec.hs
               dependencies: hspec
           |]
-          (`shouldBe` package {packageTests = [(section $ executable "spec" "test/Spec.hs") {sectionDependencies = ["hspec"]}]})
+          (`shouldBe` package {packageTests = [(section $ executable "spec" "test/Spec.hs") {sectionDependencies = Dependencies ["hspec"]}]})
 
       it "accepts list of dependencies" $ do
         withPackageConfig_ [i|
@@ -1230,7 +1230,7 @@ spec = do
                 - hspec
                 - QuickCheck
           |]
-          (`shouldBe` package {packageTests = [(section $ executable "spec" "test/Spec.hs") {sectionDependencies = ["hspec", "QuickCheck"]}]})
+          (`shouldBe` package {packageTests = [(section $ executable "spec" "test/Spec.hs") {sectionDependencies = Dependencies ["hspec", "QuickCheck"]}]})
 
       context "when both global and section specific dependencies are specified" $ do
         it "combines dependencies" $ do
@@ -1243,7 +1243,7 @@ spec = do
                 main: test/Spec.hs
                 dependencies: hspec
             |]
-            (`shouldBe` package {packageTests = [(section $ executable "spec" "test/Spec.hs") {sectionDependencies = ["base", "hspec"]}]})
+            (`shouldBe` package {packageTests = [(section $ executable "spec" "test/Spec.hs") {sectionDependencies = Dependencies ["base", "hspec"]}]})
 
     context "when a specified source directory does not exist" $ do
       it "warns" $ do

--- a/test/Hpack/ConfigSpec.hs
+++ b/test/Hpack/ConfigSpec.hs
@@ -783,6 +783,16 @@ spec = do
             |]
             [Dependency "yesod-core" (Just (GitRef "https://github.com/yesodweb/yesod" "498d373e2d0cffe38b4cba598e17f0afaf720e6e" (Just "yesod-core")))]
 
+        it "ignores name in nested hash" $ do
+          checkDependencies [i|
+            library:
+              dependencies:
+                outer-name:
+                  name: inner-name
+                  path: somewhere
+            |]
+            [Dependency "outer-name" (Just (Local "somewhere"))]
+
         it "overwrites earlier keys with later ones" $ do
           checkDependencies [i|
             library:

--- a/test/Hpack/RunSpec.hs
+++ b/test/Hpack/RunSpec.hs
@@ -128,7 +128,7 @@ spec = do
     context "when rendering custom-setup section" $ do
       it "includes setup-depends" $ do
         let setup = CustomSetup
-              { customSetupDependencies = ["foo >1.0", "bar ==2.0"] }
+              { customSetupDependencies = Dependencies ["foo >1.0", "bar ==2.0"] }
         renderPackage_ package {packageCustomSetup = Just setup} `shouldBe` unlines [
             "name: foo"
           , "version: 0.0.0"
@@ -225,7 +225,7 @@ spec = do
 
     context "when rendering executable section" $ do
       it "includes dependencies" $ do
-        renderPackage_ package {packageExecutables = [(section $ executable "foo" "Main.hs") {sectionDependencies = ["foo", "bar", "foo", "baz"]}]} `shouldBe` unlines [
+        renderPackage_ package {packageExecutables = [(section $ executable "foo" "Main.hs") {sectionDependencies = Dependencies ["foo", "bar", "foo", "baz"]}]} `shouldBe` unlines [
             "name: foo"
           , "version: 0.0.0"
           , "build-type: Simple"
@@ -269,7 +269,7 @@ spec = do
 
   describe "renderConditional" $ do
     it "renders conditionals" $ do
-      let conditional = Conditional "os(windows)" (section ()) {sectionDependencies = ["Win32"]} Nothing
+      let conditional = Conditional "os(windows)" (section ()) {sectionDependencies = Dependencies ["Win32"]} Nothing
       render defaultRenderSettings 0 (renderConditional conditional) `shouldBe` [
           "if os(windows)"
         , "  build-depends:"
@@ -277,7 +277,7 @@ spec = do
         ]
 
     it "renders conditionals with else-branch" $ do
-      let conditional = Conditional "os(windows)" (section ()) {sectionDependencies = ["Win32"]} (Just $ (section ()) {sectionDependencies = ["unix"]})
+      let conditional = Conditional "os(windows)" (section ()) {sectionDependencies = Dependencies ["Win32"]} (Just $ (section ()) {sectionDependencies = Dependencies ["unix"]})
       render defaultRenderSettings 0 (renderConditional conditional) `shouldBe` [
           "if os(windows)"
         , "  build-depends:"
@@ -289,7 +289,7 @@ spec = do
 
     it "renders nested conditionals" $ do
       let conditional = Conditional "arch(i386)" (section ()) {sectionGhcOptions = ["-threaded"], sectionConditionals = [innerConditional]} Nothing
-          innerConditional = Conditional "os(windows)" (section ()) {sectionDependencies = ["Win32"]} Nothing
+          innerConditional = Conditional "os(windows)" (section ()) {sectionDependencies = Dependencies ["Win32"]} Nothing
       render defaultRenderSettings 0 (renderConditional conditional) `shouldBe` [
           "if arch(i386)"
         , "  ghc-options: -threaded"


### PR DESCRIPTION
This pull request fixes #186. It changes the dependencies to allow hash values specifying the package as the key and the constraint as the value. Here are some allowable dependencies:

``` yaml
# As before, a single string is allowed.
dependencies: base ==4.10.0.0

# Also as before, a list of strings is allowed.
dependencies:
  - base ==4.10.0.0

# This changed! Now a hash is interpreted as "<package>: <constraint>".
dependencies:
  base: ==4.10.0.0

# Values aren't required.
dependencies:
  base:
  aeson: null

# Values can be hashes.
dependencies:
  local:
    path: the/path-to/local
  remote:
    github: user/repo
    ref: master

# Be careful with constraints that collide with YAML syntax.
dependencies:
  # base: >=4.10 # Error!
  base: '>=4.10'

# When there are duplicate keys, later keys win.
dependencies:
  base: ignored
  base: ==4.10.0.0
```

In #186 I originally suggested that the `==` constraint be implied if no constraints were given. In other words, `base: 4.10.0.0` would mean `base ==4.10.0.0`. I chose not to implement that because it would require parsing constraints, which is hard. 