### PR TITLE
Upgrade to Stackage LTS 9.0

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,1 @@
-flags: {}
-packages:
-- '.'
-extra-deps:
-- aeson-0.11.0.0
-- yaml-0.8.21.2
-resolver: lts-5.3
+resolver: lts-9.0


### PR DESCRIPTION
This upgrades the Stack configuration from GHC 7.10.2 to GHC 8.0.2. It also upgrades a whole slew of packages. Everything built fine on my machine. 

I ran into this while working on a fix for #186 because I needed a more recent version of Cabal to parse constraints in isolation. 