### PR TITLE
Allow specifying dependencies as a hash

### DIFF
--- a/src/Hpack/Run.hs
+++ b/src/Hpack/Run.hs
@@ -267,7 +267,7 @@ renderReexportedModules :: [String] -> Element
 renderReexportedModules = Field "reexported-modules" . LineSeparatedList
 
 renderDependencies :: String -> Dependencies -> Element
-renderDependencies name = Field name . CommaSeparatedList . map renderDependency . Map.toList
+renderDependencies name = Field name . CommaSeparatedList . map renderDependency . Map.toList . unwrapDependencies
 
 renderDependency :: (String, DependencyVersion) -> String
 renderDependency (name, version) = name ++ v

--- a/test/Hpack/ConfigSpec.hs
+++ b/test/Hpack/ConfigSpec.hs
@@ -30,7 +30,7 @@ instance IsString Dependency where
   fromString name = Dependency name AnyVersion
 
 deps :: [String] -> Dependencies
-deps = Map.fromList . map (flip (,) AnyVersion)
+deps = Dependencies . Map.fromList . map (flip (,) AnyVersion)
 
 package :: Package
 package = Config.package "foo" "0.0.0"
@@ -743,7 +743,7 @@ spec = do
               - foo > 1.0
               - bar == 2.0
           |]
-          (packageCustomSetup >>> fmap customSetupDependencies >>> fmap Map.toList >>> (`shouldBe` Just [
+          (packageCustomSetup >>> fmap customSetupDependencies >>> fmap unwrapDependencies >>> fmap Map.toList >>> (`shouldBe` Just [
               ("bar", VersionRange "==2.0")
             , ("foo", VersionRange ">1.0")
             ])
@@ -1278,7 +1278,7 @@ spec = do
                 main: test/Spec.hs
                 dependencies: base >= 2
             |]
-            (packageTests >>> map (Map.toList . sectionDependencies) >>> (`shouldBe` [[("base", VersionRange ">=2")]]))
+            (packageTests >>> map (Map.toList . unwrapDependencies . sectionDependencies) >>> (`shouldBe` [[("base", VersionRange ">=2")]]))
 
     context "when a specified source directory does not exist" $ do
       it "warns" $ do

--- a/test/Hpack/ConfigSpec.hs
+++ b/test/Hpack/ConfigSpec.hs
@@ -760,6 +760,81 @@ spec = do
         (packageName >>> (`shouldBe` "n2"))
 
     context "when reading library section" $ do
+      context "dependencies" $ do
+        let checkDependencies yaml dependencies = withPackageConfig_ yaml (\ x -> do
+              let expected = Just dependencies
+              let actual = Map.toAscList . unwrapDependencies . sectionDependencies <$> packageLibrary x
+              actual `shouldBe` expected)
+
+        it "accepts a string without constraints" $ do
+          checkDependencies [i|
+            library:
+              dependencies: base
+          |] [("base", AnyVersion)]
+
+        it "accepts a string with constraints" $ do
+          checkDependencies [i|
+            library:
+              dependencies: mtl ==2.2.1
+          |] [("mtl", VersionRange "==2.2.1")]
+
+        it "accepts an array of strings" $ do
+          checkDependencies [i|
+            library:
+              dependencies:
+                - containers
+          |] [("containers", AnyVersion)]
+
+        it "accepts an array of hashes" $ do
+          checkDependencies [i|
+            library:
+              dependencies:
+                - name: hpack
+                  path: ../hpack
+          |] [("hpack", SourceDependency (Local "../hpack"))]
+
+        it "accepts a hash of strings" $ do
+          checkDependencies [i|
+            library:
+              dependencies:
+                bytestring: 0.10.8.2
+          |] [("bytestring", VersionRange "0.10.8.2")]
+
+        it "accepts a hash of hashes" $ do
+          checkDependencies [i|
+            library:
+              dependencies:
+                Cabal:
+                  github: haskell/cabal
+                  ref: d53b6e0d908dfedfdf4337b2935519fb1d689e76
+                  subdir: Cabal
+          |] [("Cabal", SourceDependency (GitRef "https://github.com/haskell/cabal" "d53b6e0d908dfedfdf4337b2935519fb1d689e76" (Just "Cabal")))]
+
+        it "ignores names in nested hashes" $ do
+          checkDependencies [i|
+            library:
+              dependencies:
+                outer-name:
+                  name: inner-name
+                  path: somewhere
+          |] [("outer-name", SourceDependency (Local "somewhere"))]
+
+        it "overwrites values from earlier keys with later ones" $ do
+          checkDependencies [i|
+            library:
+              dependencies:
+                deepseq: '>=1.4.1'
+                deepseq: '>=1.4.2'
+                deepseq: '>=1.4.3'
+          |] [("deepseq", VersionRange ">=1.4.3")]
+
+        it "allows null constraints" $ do
+          checkDependencies [i|
+            library:
+              dependencies:
+                array:
+          |] [("array", AnyVersion)]
+
       it "warns on unknown fields" $ do
         withPackageWarnings_ [i|
           name: foo

--- a/test/Hpack/RunSpec.hs
+++ b/test/Hpack/RunSpec.hs
@@ -226,7 +226,7 @@ spec = do
 
     context "when rendering executable section" $ do
       it "includes dependencies" $ do
-        renderPackage_ package {packageExecutables = [(section $ executable "foo" "Main.hs") {sectionDependencies = Map.fromList
+        renderPackage_ package {packageExecutables = [(section $ executable "foo" "Main.hs") {sectionDependencies = Dependencies $ Map.fromList
         [("foo", VersionRange "== 0.1.0"), ("bar", AnyVersion)]}]} `shouldBe` unlines [
             "name: foo"
           , "version: 0.0.0"


### PR DESCRIPTION
This fixes #186. It's my second attempt after #193. 

This pull request changes the dependencies to allow hash values specifying the package as the key and the constraint as the value. Here are some allowable dependencies:

``` yaml
# As before, a single string is allowed.
dependencies: base ==4.10.0.0

# Also as before, a list of strings is allowed.
dependencies:
  - base ==4.10.0.0

# This changed! Now a hash is interpreted as "<package>: <constraint>".
dependencies:
  base: ==4.10.0.0

# Values aren't required.
dependencies:
  base:
  aeson: null

# Values can be hashes.
dependencies:
  local:
    path: the/path-to/local
  remote:
    github: user/repo
    ref: master

# Be careful with constraints that collide with YAML syntax.
dependencies:
  # base: >=4.10 # Error!
  base: '>=4.10'

# When there are duplicate keys, later keys win.
dependencies:
  base: ignored
  base: ==4.10.0.0
```

There are two things that I have not done that I would like to:

- Parse `base: 4.10.0.0` as `base ==4.10.0.0`. That is, use `==` as the constraint if none is given. I haven't done this yet because it will require parsing `DependencyVersion` values into actual `VersionRange`s.

- Merge dependencies from the `library` section into other sections. If you have `library: { dependencies: base ==4.8.* }` and `tests: { test: { dependencies: base >=4.8.2 } }`, the test's dependency on base should be `==4.8.* && >=4.8.2`. I haven't done this yet because it will require mucking around in `mkPackage`. 