### PR TITLE
Add frameworks and extra-frameworks-dirs fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ These fields are merged with all library, executable, test, and benchmark compon
 | `extra-libraries` | · | | |
 | `include-dirs` | · | | |
 | `install-includes` | · | | |
+| `frameworks` | · | | |
+| `extra-frameworks-dirs` | · | | |
 | `ld-options` | · | | |
 | `buildable` | · | | May be overridden by later stanza |
 | `dependencies` | `build-depends` | | |

--- a/src/Hpack/Config.hs
+++ b/src/Hpack/Config.hs
@@ -126,7 +126,7 @@ packageDependencies Package{..} = nub . sortBy (comparing (lexicographically . f
     deps xs = [(name, version) | (name, version) <- (Map.toList . unDependencies . sectionDependencies) xs]
 
 section :: a -> Section a
-section a = Section a [] mempty [] [] [] [] [] [] [] [] [] [] [] [] [] [] Nothing [] mempty
+section a = Section a [] mempty [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] Nothing [] mempty
 
 packageConfig :: FilePath
 packageConfig = "package.yaml"
@@ -241,6 +241,8 @@ data CommonOptions = CommonOptions {
 , commonOptionsJsSources :: Maybe (List FilePath)
 , commonOptionsExtraLibDirs :: Maybe (List FilePath)
 , commonOptionsExtraLibraries :: Maybe (List FilePath)
+, commonOptionsExtraFrameworksDirs :: Maybe (List FilePath)
+, commonOptionsFrameworks :: Maybe (List String)
 , commonOptionsIncludeDirs :: Maybe (List FilePath)
 , commonOptionsInstallIncludes :: Maybe (List FilePath)
 , commonOptionsLdOptions :: Maybe (List LdOption)
@@ -436,6 +438,8 @@ data Section a = Section {
 , sectionJsSources :: [FilePath]
 , sectionExtraLibDirs :: [FilePath]
 , sectionExtraLibraries :: [FilePath]
+, sectionExtraFrameworksDirs :: [FilePath]
+, sectionFrameworks :: [FilePath]
 , sectionIncludeDirs :: [FilePath]
 , sectionInstallIncludes :: [FilePath]
 , sectionLdOptions :: [LdOption]
@@ -736,6 +740,8 @@ mergeSections globalOptions options
   , sectionJsSources = sectionJsSources globalOptions ++ sectionJsSources options
   , sectionExtraLibDirs = sectionExtraLibDirs globalOptions ++ sectionExtraLibDirs options
   , sectionExtraLibraries = sectionExtraLibraries globalOptions ++ sectionExtraLibraries options
+  , sectionExtraFrameworksDirs = sectionExtraFrameworksDirs globalOptions ++ sectionExtraFrameworksDirs options
+  , sectionFrameworks = sectionFrameworks globalOptions ++ sectionFrameworks options
   , sectionIncludeDirs = sectionIncludeDirs globalOptions ++ sectionIncludeDirs options
   , sectionInstallIncludes = sectionInstallIncludes globalOptions ++ sectionInstallIncludes options
   , sectionLdOptions = sectionLdOptions globalOptions ++ sectionLdOptions options
@@ -762,6 +768,8 @@ toSection a CommonOptions{..}
       , sectionJsSources = fromMaybeList commonOptionsJsSources
       , sectionExtraLibDirs = fromMaybeList commonOptionsExtraLibDirs
       , sectionExtraLibraries = fromMaybeList commonOptionsExtraLibraries
+      , sectionExtraFrameworksDirs = fromMaybeList commonOptionsExtraFrameworksDirs
+      , sectionFrameworks = fromMaybeList commonOptionsFrameworks
       , sectionIncludeDirs = fromMaybeList commonOptionsIncludeDirs
       , sectionInstallIncludes = fromMaybeList commonOptionsInstallIncludes
       , sectionLdOptions = fromMaybeList commonOptionsLdOptions

--- a/src/Hpack/Run.hs
+++ b/src/Hpack/Run.hs
@@ -232,6 +232,8 @@ renderSection Section{..} = [
   , Field "js-sources" (LineSeparatedList sectionJsSources)
   , renderDirectories "extra-lib-dirs" sectionExtraLibDirs
   , Field "extra-libraries" (LineSeparatedList sectionExtraLibraries)
+  , renderDirectories "extra-frameworks-dirs" sectionExtraFrameworksDirs
+  , Field "frameworks" (LineSeparatedList sectionFrameworks)
   , renderLdOptions sectionLdOptions
   , renderDependencies "build-depends" sectionDependencies
   , renderDependencies "build-tools" sectionBuildTools

--- a/test/Hpack/ConfigSpec.hs
+++ b/test/Hpack/ConfigSpec.hs
@@ -148,6 +148,24 @@ spec = do
         captureUnknownFieldsValue <$> decodeEither input
           `shouldBe` Right (section Empty){sectionExtraLibraries = ["foo", "bar"]}
 
+      it "accepts extra-frameworks-dirs" $ do
+        let input = [i|
+              extra-frameworks-dirs:
+                - foo
+                - bar
+              |]
+        captureUnknownFieldsValue <$> decodeEither input
+          `shouldBe` Right (section Empty){sectionExtraFrameworksDirs = ["foo", "bar"]}
+
+      it "accepts frameworks" $ do
+        let input = [i|
+              frameworks:
+                - foo
+                - bar
+              |]
+        captureUnknownFieldsValue <$> decodeEither input
+          `shouldBe` Right (section Empty){sectionFrameworks = ["foo", "bar"]}
+
       context "when parsing conditionals" $ do
         it "accepts conditionals" $ do
           let input = [i|

--- a/test/Hpack/RunSpec.hs
+++ b/test/Hpack/RunSpec.hs
@@ -254,6 +254,36 @@ spec = do
           , "  default-language: Haskell2010"
           ]
 
+      it "includes frameworks" $ do
+        renderPackage_ package {packageExecutables = [(section $ Executable "foo" "Main.hs" []) {sectionFrameworks = ["foo", "bar"]}]} `shouldBe` unlines [
+            "name: foo"
+          , "version: 0.0.0"
+          , "build-type: Simple"
+          , "cabal-version: >= 1.10"
+          , ""
+          , "executable foo"
+          , "  main-is: Main.hs"
+          , "  frameworks:"
+          , "      foo"
+          , "      bar"
+          , "  default-language: Haskell2010"
+          ]
+
+      it "includes extra-framework-dirs" $ do
+        renderPackage_ package {packageExecutables = [(section $ Executable "foo" "Main.hs" []) {sectionExtraFrameworksDirs = ["foo", "bar"]}]} `shouldBe` unlines [
+            "name: foo"
+          , "version: 0.0.0"
+          , "build-type: Simple"
+          , "cabal-version: >= 1.10"
+          , ""
+          , "executable foo"
+          , "  main-is: Main.hs"
+          , "  extra-frameworks-dirs:"
+          , "      foo"
+          , "      bar"
+          , "  default-language: Haskell2010"
+          ]
+
       it "includes GHC profiling options" $ do
         renderPackage_ package {packageExecutables = [(section $ Executable "foo" "Main.hs" []) {sectionGhcProfOptions = ["-fprof-auto", "-rtsopts"]}]} `shouldBe` unlines [
             "name: foo"


### PR DESCRIPTION
[`frameworks`](https://www.haskell.org/cabal/users-guide/developing-packages.html#pkg-field-frameworks) and [`extra-frameworks-dirs`](https://www.haskell.org/cabal/users-guide/developing-packages.html#pkg-field-extra-frameworks-dirs) are macOS-specific fields for linking against [frameworks](https://developer.apple.com/library/content/documentation/MacOSX/Conceptual/OSX_Technology_Overview/SystemFrameworks/SystemFrameworks.html). Useful, for example, when writing FFI shims around macOS ObjectiveC APIs.