### PR TITLE
make github field accept an object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
   - `extra-doc-files` requires setting `cabal-version` to at least
     1.18; this is now done properly.
   - Accept bool for `condition` (see #230)
+  - Allow `github` to be an object, which newly permits setting the branch
+    and the homepage anchor, as well as the subdirectory.
+
+    This changes the generated homepage of any project using `github`
+    with a subdirectory: previously it pointed to the repository's
+    root, but now it points into the subdirectory.
 
 ## Changes in 0.21.2
   - Fix a bug in module inference for conditionals (see #236)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ existing cabal file into a `package.yaml`.
 | `description` | · | | | | |
 | `category` | · | | | | |
 | `stability` | · | | | | |
-| `homepage` | · | If `github` given, `<repo>#readme` | | | |
+| `homepage` | · | If `github` given, `<repo>(/tree/<branch>)(/<subdir>)(#<anchor>)` | | | |
 | `bug-reports` | · | If `github` given, `<repo>/issues` | | | |
 | `author` | · | | May be a list | | |
 | `maintainer` | · | | May be a list | | |

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ existing cabal file into a `package.yaml`.
 | `extra-source-files` | · | | Accepts [glob patterns](#file-globbing) | | |
 | `extra-doc-files` | · | | Accepts [glob patterns](#file-globbing) | | `0.21.2` |
 | `data-files` | · | | Accepts [glob patterns](#file-globbing) | | |
-| `github` | `source-repository head` | | Accepts `user/repo` or `user/repo/subdir` | `github: foo/bar` |
+| `github` | `source-repository head` | | Accepts `user/repo` or `user/repo/subdir`, or [an object with fields, as specified below](#github-fields) | `github: foo/bar` | As an object: `0.21.0` |
 | `git`    | `source-repository head` | | No effect if `github` given | `git: https://my.repo.com/foo` | |
 | `custom-setup` | · | | See [Custom setup](#custom-setup) | | |
 | `flags`  | `flag <name>` | | Map from flag name to flag (see [Flags](#flags)) | | |
@@ -116,6 +116,15 @@ this reason it is recommended to only use tags as Git references.
  * If you want to prevent Hpack from accessing the network to download a
    defaults file, then you can achieve this by adding that file to the cache
    manually.
+
+#### <a name="github-fields"></a>Github fields
+
+| Hpack | Default | Notes
+| --- | --- | --- |
+| repo | Mandatory
+| subdir | `/` | If a homepage URL is generated from the Github description, it will point into this directory.
+| branch | `HEAD` |
+| homepage-anchor | `readme` | If a homepage URL is generated from the Github description, it will point to this anchor. Set to `null` for no anchor.
 
 #### <a name="custom-setup"></a>Custom setup
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ existing cabal file into a `package.yaml`.
 | `extra-source-files` | · | | Accepts [glob patterns](#file-globbing) | | |
 | `extra-doc-files` | · | | Accepts [glob patterns](#file-globbing) | | `0.21.2` |
 | `data-files` | · | | Accepts [glob patterns](#file-globbing) | | |
-| `github` | `source-repository head` | | Accepts `user/repo` or `user/repo/subdir`, or [an object with fields, as specified below](#github-fields) | `github: foo/bar` | As an object: `0.21.0` |
+| `github` | `source-repository head` | | Accepts `user/repo` or `user/repo/subdir`, or [an object with fields, as specified below](#github-fields) | `github: foo/bar` | As an object: `0.22.0` |
 | `git`    | `source-repository head` | | No effect if `github` given | `git: https://my.repo.com/foo` | |
 | `custom-setup` | · | | See [Custom setup](#custom-setup) | | |
 | `flags`  | `flag <name>` | | Map from flag name to flag (see [Flags](#flags)) | | |

--- a/src/Hpack/Run.hs
+++ b/src/Hpack/Run.hs
@@ -182,6 +182,7 @@ renderSourceRepository SourceRepository{..} = Stanza "source-repository head" [
     Field "type" "git"
   , Field "location" (Literal sourceRepositoryUrl)
   , Field "subdir" (maybe "" Literal sourceRepositorySubdir)
+  , Field "branch" (maybe "" Literal sourceRepositoryBranch)
   ]
 
 renderFlag :: Flag -> Element

--- a/test/Hpack/RunSpec.hs
+++ b/test/Hpack/RunSpec.hs
@@ -323,7 +323,7 @@ spec = do
 
   describe "renderSourceRepository" $ do
     it "renders source-repository without subdir correctly" $ do
-      let repository = SourceRepository "https://github.com/hspec/hspec" Nothing
+      let repository = SourceRepository "https://github.com/hspec/hspec" Nothing Nothing
       (render defaultRenderSettings 0 $ renderSourceRepository repository)
         `shouldBe` [
             "source-repository head"
@@ -332,13 +332,23 @@ spec = do
           ]
 
     it "renders source-repository with subdir" $ do
-      let repository = SourceRepository "https://github.com/hspec/hspec" (Just "hspec-core")
+      let repository = SourceRepository "https://github.com/hspec/hspec" (Just "hspec-core") Nothing
       (render defaultRenderSettings 0 $ renderSourceRepository repository)
         `shouldBe` [
             "source-repository head"
           , "  type: git"
           , "  location: https://github.com/hspec/hspec"
           , "  subdir: hspec-core"
+          ]
+
+    it "renders source-repository with branch" $ do
+      let repository = SourceRepository "https://github.com/hspec/hspec" Nothing (Just "some-branch")
+      (render defaultRenderSettings 0 $ renderSourceRepository repository)
+        `shouldBe` [
+            "source-repository head"
+          , "  type: git"
+          , "  location: https://github.com/hspec/hspec"
+          , "  branch: some-branch"
           ]
 
   describe "renderDirectories" $ do


### PR DESCRIPTION
This is preferable to inventing a syntax for subdirectories, branches, etc ourselves, with all the benefits of being able to name the parts.

There's a behaviour change as noted in the changelog.

Maybe `branch` should be renamed `ref`. `git` fields could be made to accept similar objects, but this isn't done (yet).

I have to figure out how to get the generic machinery to do what I want, I think, rather than a hand-written FromJSON instance, if I want warnings?