### PR TITLE
Implement generated-other/exposed-modules.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
   - `extra-doc-files` requires setting `cabal-version` to at least
     1.18; this is now done properly.
   - Accept bool for `condition` (see #230)
+  - `generated-exposed-modules` and `generated-other-modules`, for populating
+    the `autogen-modules` field (#207).
 
 ## Changes in 0.21.2
   - Fix a bug in module inference for conditionals (see #236)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   - Accept bool for `condition` (see #230)
   - `generated-exposed-modules` and `generated-other-modules`, for populating
     the `autogen-modules` field (#207).
+  - Corrected `cabal-version` setting for `reexported-modules` inside
+    a conditional.
 
 ## Changes in 0.21.2
   - Fix a bug in module inference for conditionals (see #236)

--- a/README.md
+++ b/README.md
@@ -155,11 +155,13 @@ values are merged with per section values.
 
 #### <a name="library-fields"></a>Library fields
 
-| Hpack | Cabal | Default | Default inside conditional |
+| Hpack | Cabal | Default | Notes |
 | --- | --- | --- | --- |
 | `exposed` | · | | |
 | `exposed-modules` | · | All modules in `source-dirs` less `other-modules` less any modules mentioned in `when` | |
-| `other-modules` | · | All modules in `source-dirs` less `exposed-modules` less any modules mentioned in `when` | Only if `exposed-modules` is not specified inside the conditional: All modules in `source-dirs` of the conditional less any modules mentioned in `when` of the conditional |
+| `generated-exposed-modules` | | | Added to `exposed-modules` and `autogen-modules`. Since `0.22.0`.
+| `other-modules` | · | Outside conditionals: All modules in `source-dirs` less `exposed-modules` less any modules mentioned in `when`. Inside conditionals, and only if `exposed-modules` is not specified inside the conditional: All modules in `source-dirs` of the conditional less any modules mentioned in `when` of the conditional | |
+| `generated-other-modules` | | | Added to `other-modules` and `autogen-modules`. Since `0.22.0`.
 | `reexported-modules` | · | | |
 | `signatures` | · | | |
 | | `default-language` | `Haskell2010` | |
@@ -170,6 +172,7 @@ values are merged with per section values.
 | --- | --- | --- | --- |
 | `main` | `main-is` | | |
 | `other-modules` | · | All modules in `source-dirs` less `main` less any modules mentioned in `when` | |
+| `generated-other-modules` | | | Added to `other-modules` and `autogen-modules`. Since `0.22.0`.
 | | `default-language` | `Haskell2010` | |
 
 #### <a name="test-fields"></a>Test fields
@@ -179,6 +182,7 @@ values are merged with per section values.
 | | `type` | `exitcode-stdio-1.0` | |
 | `main` | `main-is` | | |
 | `other-modules` | · | All modules in `source-dirs` less `main` less any modules mentioned in `when` | |
+| `generated-other-modules` | | | Added to `other-modules` and `autogen-modules`. Since `0.22.0`.
 | | `default-language` | `Haskell2010` | |
 
 #### <a name="benchmark-fields"></a>Benchmark fields
@@ -188,6 +192,7 @@ values are merged with per section values.
 | | `type` | `exitcode-stdio-1.0` | |
 | `main` | `main-is` | | |
 | `other-modules` | · | All modules in `source-dirs` less `main` less any modules mentioned in `when` | |
+| `generated-other-modules` | | | Added to `other-modules` and `autogen-modules`. Since `0.22.0`.
 | | `default-language` | `Haskell2010` | |
 
 #### <a name="flags"></a>Flags

--- a/src/Hpack/Config.hs
+++ b/src/Hpack/Config.hs
@@ -923,11 +923,11 @@ toLibrary dir name globalOptions =
 
 determineModules :: [String] -> [String] -> Maybe (List String) -> Maybe (List String) -> Maybe (List String) -> Maybe (List String) -> ([String], [String], [String])
 determineModules pathsModule inferableModules mExposedModules mGeneratedExposedModules mOtherModules mGeneratedOtherModules = case (mExposedModules, mOtherModules) of
-  (Nothing, Nothing) -> (inferableModules ++ maybe [] fromList mGeneratedExposedModules, pathsModule ++ maybe [] fromList mGeneratedOtherModules, generatedModules)
+  (Nothing, Nothing) -> ((inferableModules \\ generatedModules) ++ maybe [] fromList mGeneratedExposedModules, pathsModule ++ maybe [] fromList mGeneratedOtherModules, generatedModules)
   _ -> (exposedModules, otherModules, generatedModules)
   where
-    exposedModules = maybe (inferableModules \\ otherModules) fromList mExposedModules ++ maybe [] fromList mGeneratedExposedModules
-    otherModules   = maybe ((inferableModules ++ pathsModule) \\ exposedModules) fromList mOtherModules ++ maybe [] fromList mGeneratedOtherModules
+    exposedModules = maybe (inferableModules \\ (otherModules ++ generatedModules)) fromList mExposedModules ++ maybe [] fromList mGeneratedExposedModules
+    otherModules   = maybe ((inferableModules ++ pathsModule) \\ (exposedModules ++ generatedModules)) fromList mOtherModules ++ maybe [] fromList mGeneratedOtherModules
     generatedModules = maybe [] fromList mGeneratedOtherModules ++ maybe [] fromList mGeneratedExposedModules
 
 fromLibrarySectionInConditional :: [String] -> LibrarySection -> Library
@@ -966,7 +966,7 @@ toExecutable dir packageName_ globalOptions =
     fromExecutableSection pathsModule inferableModules ExecutableSection{..} =
       (Executable executableSectionMain (otherModules ++ generatedModules) generatedModules)
       where
-        otherModules = maybe (inferableModules ++ pathsModule) fromList executableSectionOtherModules
+        otherModules = maybe ((inferableModules \\ generatedModules) ++ pathsModule) fromList executableSectionOtherModules
         generatedModules = maybe [] fromList executableSectionGeneratedOtherModules
 
 expandMain :: Section ExecutableSection -> Section ExecutableSection

--- a/src/Hpack/Config.hs
+++ b/src/Hpack/Config.hs
@@ -923,8 +923,8 @@ toLibrary dir name globalOptions =
         signatures = fromMaybeList librarySectionSignatures
 
 data ModuleSpecification = ModuleSpecification {
-  moduleSpecificationModules :: Maybe (List String)
-, moduleSpecificationGeneratedModules :: Maybe (List String)
+  _moduleSpecificationModules :: Maybe (List String)
+, _moduleSpecificationGeneratedModules :: Maybe (List String)
 } deriving (Show, Eq)
 
 determineModules :: [String] -> [String] -> ModuleSpecification -> ModuleSpecification -> ([String], [String], [String])

--- a/src/Hpack/Config.hs
+++ b/src/Hpack/Config.hs
@@ -36,6 +36,7 @@ module Hpack.Config (
 , Empty(..)
 , getModules
 , pathsModuleFromPackageName
+, ModuleSpecification(..)
 , determineModules
 , BuildType(..)
 , Cond(..)
@@ -917,12 +918,17 @@ toLibrary dir name globalOptions =
       Library librarySectionExposed exposedModules otherModules generatedModules reexportedModules signatures
       where
         (exposedModules, otherModules, generatedModules) =
-          determineModules pathsModule inferableModules librarySectionExposedModules librarySectionGeneratedExposedModules librarySectionOtherModules librarySectionGeneratedOtherModules
+          determineModules pathsModule inferableModules (ModuleSpecification librarySectionExposedModules librarySectionGeneratedExposedModules) (ModuleSpecification librarySectionOtherModules librarySectionGeneratedOtherModules)
         reexportedModules = fromMaybeList librarySectionReexportedModules
         signatures = fromMaybeList librarySectionSignatures
 
-determineModules :: [String] -> [String] -> Maybe (List String) -> Maybe (List String) -> Maybe (List String) -> Maybe (List String) -> ([String], [String], [String])
-determineModules pathsModule inferableModules mExposedModules mGeneratedExposedModules mOtherModules mGeneratedOtherModules = case (mExposedModules, mOtherModules) of
+data ModuleSpecification = ModuleSpecification {
+  moduleSpecificationModules :: Maybe (List String)
+, moduleSpecificationGeneratedModules :: Maybe (List String)
+} deriving (Show, Eq)
+
+determineModules :: [String] -> [String] -> ModuleSpecification -> ModuleSpecification -> ([String], [String], [String])
+determineModules pathsModule inferableModules (ModuleSpecification mExposedModules mGeneratedExposedModules) (ModuleSpecification mOtherModules mGeneratedOtherModules) = case (mExposedModules, mOtherModules) of
   (Nothing, Nothing) -> ((inferableModules \\ generatedModules) ++ maybe [] fromList mGeneratedExposedModules, pathsModule ++ maybe [] fromList mGeneratedOtherModules, generatedModules)
   _ -> (exposedModules, otherModules, generatedModules)
   where

--- a/src/Hpack/Run.hs
+++ b/src/Hpack/Run.hs
@@ -132,7 +132,7 @@ renderPackage settings alignment existingFieldOrder sectionsFieldOrder Package{.
     cabalVersion = (">= " ++) . showVersion <$> maximum [
         Just (makeVersion [1,10])
       , packageCabalVersion
-      , packageLibrary >>= libraryCabalVersion . sectionData
+      , packageLibrary >>= libraryCabalVersion
       , internalLibsCabalVersion packageInternalLibraries
       , executablesCabalVersion packageExecutables
       , executablesCabalVersion packageTests
@@ -146,16 +146,16 @@ renderPackage settings alignment existingFieldOrder sectionsFieldOrder Package{.
         , makeVersion [1,18] <$ guard (not (null packageExtraDocFiles))
         ]
 
-      libraryCabalVersion :: Library -> Maybe Version
-      libraryCabalVersion Library{..} = maximum [
+      libraryCabalVersion :: Section Library -> Maybe Version
+      libraryCabalVersion sect = maximum [
           makeVersion [1,22] <$ guard hasReexportedModules
         , makeVersion [2,0]  <$ guard hasSignatures
         , makeVersion [2,0] <$ guard hasGeneratedModules
         ]
         where
-          hasReexportedModules = (not . null) libraryReexportedModules
-          hasSignatures = (not . null) librarySignatures
-          hasGeneratedModules = (not . null) libraryGeneratedModules
+          hasReexportedModules = any (not . null . libraryReexportedModules) sect
+          hasSignatures = any (not . null . librarySignatures) sect
+          hasGeneratedModules = any (not . null . libraryGeneratedModules) sect
 
       internalLibsCabalVersion :: Map String (Section Library) -> Maybe Version
       internalLibsCabalVersion internalLibraries = makeVersion [2,0] <$ guard (not (Map.null internalLibraries))
@@ -167,7 +167,7 @@ renderPackage settings alignment existingFieldOrder sectionsFieldOrder Package{.
       executableCabalVersion sect = makeVersion [2,0] <$ guard (executableHasGeneratedModules sect)
 
       executableHasGeneratedModules :: Section Executable -> Bool
-      executableHasGeneratedModules = not . null . executableGeneratedModules . sectionData
+      executableHasGeneratedModules = any (not . null . executableGeneratedModules)
 
 sortSectionFields :: [(String, [String])] -> [Element] -> [Element]
 sortSectionFields sectionsFieldOrder = go

--- a/test/EndToEndSpec.hs
+++ b/test/EndToEndSpec.hs
@@ -440,6 +440,29 @@ spec = around_ (inTempDirectoryNamed "foo") $ do
                 Paths_foo
             |]
 
+          it "doesn't doubly include generated modules under src/" $ do
+            touch "src/ABC.hs"
+            touch "src/XYZ.hs"
+            [i|
+            library:
+              source-dirs: src
+              exposed-modules: Foo
+              generated-other-modules: ABC
+              generated-exposed-modules: XYZ
+            |] `shouldRenderTo` (library [i|
+            hs-source-dirs:
+                src
+            exposed-modules:
+                Foo
+                XYZ
+            other-modules:
+                Paths_foo
+                ABC
+            autogen-modules:
+                ABC
+                XYZ
+            |]) {packageCabalVersion = ">= 2.0"}
+
         context "with other-modules" $ do
           it "infers exposed-modules" $ do
             touch "src/Foo.hs"
@@ -456,6 +479,28 @@ spec = around_ (inTempDirectoryNamed "foo") $ do
             other-modules:
                 Bar
             |]
+
+          it "doesn't doubly include generated modules under src/" $ do
+            touch "src/ABC.hs"
+            touch "src/XYZ.hs"
+            [i|
+            library:
+              source-dirs: src
+              other-modules: Foo
+              generated-other-modules: ABC
+              generated-exposed-modules: XYZ
+            |] `shouldRenderTo` (library [i|
+            hs-source-dirs:
+                src
+            exposed-modules:
+                XYZ
+            other-modules:
+                Foo
+                ABC
+            autogen-modules:
+                ABC
+                XYZ
+            |]) {packageCabalVersion = ">= 2.0"}
 
         context "with both exposed-modules and other-modules" $ do
           it "doesn't infer any modules" $ do
@@ -491,6 +536,27 @@ spec = around_ (inTempDirectoryNamed "foo") $ do
             other-modules:
                 Paths_foo
             |]
+
+          it "doesn't doubly include generated modules under src/" $ do
+            touch "src/ABC.hs"
+            touch "src/XYZ.hs"
+            [i|
+            library:
+              source-dirs: src
+              generated-other-modules: ABC
+              generated-exposed-modules: XYZ
+            |] `shouldRenderTo` (library [i|
+            hs-source-dirs:
+                src
+            exposed-modules:
+                XYZ
+            other-modules:
+                Paths_foo
+                ABC
+            autogen-modules:
+                ABC
+                XYZ
+            |]) {packageCabalVersion = ">= 2.0"}
 
         context "with a conditional" $ do
           it "doesn't infer any modules mentioned in that conditional" $ do
@@ -675,6 +741,25 @@ spec = around_ (inTempDirectoryNamed "foo") $ do
             other-modules:
                 Baz
           |]
+
+        it "doesn't doubly include generated modules under src/" $ do
+          touch "src/XYZ.hs"
+          [i|
+          executables:
+            foo:
+              main: Main.hs
+              source-dirs: src
+              generated-other-modules: XYZ
+          |] `shouldRenderTo` (executable "foo" [i|
+            main-is: Main.hs
+            hs-source-dirs:
+                src
+            other-modules:
+                Paths_foo
+                XYZ
+            autogen-modules:
+                XYZ
+          |]) {packageCabalVersion = ">= 2.0"}
 
         context "with conditional" $ do
           it "doesn't infer any modules mentioned in that conditional" $ do

--- a/test/EndToEndSpec.hs
+++ b/test/EndToEndSpec.hs
@@ -656,6 +656,59 @@ spec = around_ (inTempDirectoryNamed "foo") $ do
               Exposed
           |]) {packageCabalVersion = ">= 2.0"}
 
+        it "sets cabal-version to 2.0 when there are conditional generated modules" $
+          [i|
+          library:
+            source-dirs: src
+            when:
+              condition: os(windows)
+              generated-exposed-modules: Win
+          |] `shouldRenderTo` (library [i|
+          other-modules:
+              Paths_foo
+          hs-source-dirs:
+              src
+          if os(windows)
+            exposed-modules:
+                Win
+            autogen-modules:
+                Win
+         |]) {packageCabalVersion = ">= 2.0"}
+
+        it "sets cabal-version to 2.0 when there are conditional signatures" $
+          [i|
+          library:
+            source-dirs: src
+            when:
+              condition: os(windows)
+              signatures: Foo
+          |] `shouldRenderTo` (library [i|
+          other-modules:
+              Paths_foo
+          hs-source-dirs:
+              src
+          if os(windows)
+            signatures:
+                Foo
+         |]) {packageCabalVersion = ">= 2.0"}
+
+        it "sets cabal-version to 1.22 when there are conditional re-exports" $
+          [i|
+          library:
+            source-dirs: src
+            when:
+              condition: os(windows)
+              reexported-modules: Foo
+          |] `shouldRenderTo` (library [i|
+          other-modules:
+              Paths_foo
+          hs-source-dirs:
+              src
+          if os(windows)
+            reexported-modules:
+                Foo
+         |]) {packageCabalVersion = ">= 1.22"}
+
     context "with internal-libraries" $ do
       it "accepts internal-libraries" $ do
         touch "src/Foo.hs"
@@ -834,6 +887,23 @@ spec = around_ (inTempDirectoryNamed "foo") $ do
             main-is: Foo.hs
             ghc-options: -main-is Foo
           |]
+
+        it "sets cabal-version to 2.0 when using conditional generated modules" $ do
+          [i|
+          executables:
+            foo:
+              main: Main.hs
+              when:
+                condition: os(windows)
+                generated-other-modules: Win
+          |]  `shouldRenderTo` (executable_ "foo" [i|
+          if os(windows)
+            other-modules:
+                Win
+            autogen-modules:
+                Win
+          main-is: Main.hs
+          |]) {packageCabalVersion = ">= 2.0"}
 
     describe "when" $ do
       it "accepts conditionals" $ do

--- a/test/EndToEndSpec.hs
+++ b/test/EndToEndSpec.hs
@@ -405,6 +405,22 @@ spec = around_ (inTempDirectoryNamed "foo") $ do
             Paths_foo
         |]) {packageCabalVersion = ">= 1.22"}
 
+      it "includes all generated modules" $ do
+        [i|
+        library:
+          generated-exposed-modules: ABC
+          generated-other-modules: XYZ
+        |] `shouldRenderTo` (library [i|
+        exposed-modules:
+            ABC
+        other-modules:
+            Paths_foo
+            XYZ
+        autogen-modules:
+            XYZ
+            ABC
+        |]) {packageCabalVersion = ">= 2.0"}
+
       context "when inferring modules" $ do
         context "with exposed-modules" $ do
           it "infers other-modules" $ do
@@ -543,6 +559,37 @@ spec = around_ (inTempDirectoryNamed "foo") $ do
                     unix/
               |]
 
+        it "includes all generated modules" $ do
+          [i|
+          library:
+            source-dirs: src
+            generated-exposed-modules: Exposed
+            generated-other-modules: Other
+            when:
+              condition: os(windows)
+              generated-exposed-modules: WinExposed
+              generated-other-modules: WinOther
+          |] `shouldRenderTo` (library [i|
+          hs-source-dirs:
+              src
+          if os(windows)
+            exposed-modules:
+                WinExposed
+            other-modules:
+                WinOther
+            autogen-modules:
+                WinOther
+                WinExposed
+          exposed-modules:
+              Exposed
+          other-modules:
+              Paths_foo
+              Other
+          autogen-modules:
+              Other
+              Exposed
+          |]) {packageCabalVersion = ">= 2.0"}
+
     context "with internal-libraries" $ do
       it "accepts internal-libraries" $ do
         touch "src/Foo.hs"
@@ -628,6 +675,7 @@ spec = around_ (inTempDirectoryNamed "foo") $ do
             other-modules:
                 Baz
           |]
+
         context "with conditional" $ do
           it "doesn't infer any modules mentioned in that conditional" $ do
             touch "src/Foo.hs"

--- a/test/Hpack/ConfigSpec.hs
+++ b/test/Hpack/ConfigSpec.hs
@@ -38,10 +38,10 @@ package :: Package
 package = Config.package "foo" "0.0.0"
 
 executable :: String -> Executable
-executable main_ = Executable (Just main_) ["Paths_foo"]
+executable main_ = Executable (Just main_) ["Paths_foo"] []
 
 library :: Library
-library = Library Nothing [] ["Paths_foo"] [] []
+library = Library Nothing [] ["Paths_foo"] [] [] []
 
 withPackage :: String -> IO () -> ((Package, [String]) -> Expectation) -> Expectation
 withPackage content beforeAction expectation = withTempDirectory $ \dir_ -> do
@@ -72,21 +72,35 @@ spec = do
 
   describe "determineModules" $ do
     it "adds the Paths_* module to the other-modules" $ do
-      determineModules ["Paths_foo"] [] ["Foo"] Nothing `shouldBe` (["Foo"], ["Paths_foo"])
+      determineModules ["Paths_foo"] [] ["Foo"] Nothing Nothing Nothing `shouldBe` (["Foo"], ["Paths_foo"], [])
 
     it "adds the Paths_* module to the other-modules when no modules are specified" $ do
-      determineModules ["Paths_foo"] [] Nothing Nothing `shouldBe` ([], ["Paths_foo"])
+      determineModules ["Paths_foo"] [] Nothing Nothing Nothing Nothing `shouldBe` ([], ["Paths_foo"], [])
 
     context "when the Paths_* module is part of the exposed-modules" $ do
       it "does not add the Paths_* module to the other-modules" $ do
-        determineModules ["Paths_foo"] [] ["Foo", "Paths_foo"] Nothing `shouldBe` (["Foo", "Paths_foo"], [])
+        determineModules ["Paths_foo"] [] ["Foo", "Paths_foo"] Nothing Nothing Nothing `shouldBe` (["Foo", "Paths_foo"], [], [])
+
+    it "includes all generated modules when exposed-modules and other-modules are Nothing" $ do
+      determineModules ["Paths_foo"] [] Nothing ["ABC"] Nothing ["XYZ"] `shouldBe` (["ABC"], ["Paths_foo", "XYZ"], ["XYZ", "ABC"])
+
+    it "includes all generated modules when given explicit exposed-modules" $
+      determineModules ["Paths_foo"] [] ["Foo"] ["ABC"] Nothing ["XYZ"] `shouldBe` (["Foo", "ABC"], ["Paths_foo", "XYZ"], ["XYZ", "ABC"])
+
+    it "includes all generated modules when given explicit exposed-modules and other-modules" $
+      determineModules ["Paths_foo"] [] ["Foo"] ["ABC"] ["Internal"] ["XYZ"] `shouldBe` (["Foo", "ABC"], ["Internal", "XYZ"], ["XYZ", "ABC"])
+
+    it "includes all generated modules when given explicit other-modules" $
+      determineModules ["Paths_foo"] [] Nothing ["ABC"] ["Internal"] ["XYZ"] `shouldBe` (["ABC"], ["Internal", "XYZ"], ["XYZ", "ABC"])
 
   describe "fromLibrarySectionInConditional" $ do
     let
       sect = LibrarySection {
         librarySectionExposed = Nothing
       , librarySectionExposedModules = Nothing
+      , librarySectionGeneratedExposedModules = Nothing
       , librarySectionOtherModules = Nothing
+      , librarySectionGeneratedOtherModules = Nothing
       , librarySectionReexportedModules = Nothing
       , librarySectionSignatures = Nothing
       }
@@ -94,6 +108,7 @@ spec = do
         libraryExposed = Nothing
       , libraryExposedModules = []
       , libraryOtherModules = []
+      , libraryGeneratedModules = []
       , libraryReexportedModules = []
       , librarySignatures = []
       }

--- a/test/Hpack/ConfigSpec.hs
+++ b/test/Hpack/ConfigSpec.hs
@@ -72,26 +72,40 @@ spec = do
 
   describe "determineModules" $ do
     it "adds the Paths_* module to the other-modules" $ do
-      determineModules ["Paths_foo"] [] ["Foo"] Nothing Nothing Nothing `shouldBe` (["Foo"], ["Paths_foo"], [])
+      let exposed = ModuleSpecification ["Foo"] Nothing
+          other = ModuleSpecification Nothing Nothing
+      determineModules ["Paths_foo"] [] exposed other `shouldBe` (["Foo"], ["Paths_foo"], [])
 
     it "adds the Paths_* module to the other-modules when no modules are specified" $ do
-      determineModules ["Paths_foo"] [] Nothing Nothing Nothing Nothing `shouldBe` ([], ["Paths_foo"], [])
+      let exposed = ModuleSpecification Nothing Nothing
+          other = ModuleSpecification Nothing Nothing
+      determineModules ["Paths_foo"] [] exposed other `shouldBe` ([], ["Paths_foo"], [])
 
     context "when the Paths_* module is part of the exposed-modules" $ do
       it "does not add the Paths_* module to the other-modules" $ do
-        determineModules ["Paths_foo"] [] ["Foo", "Paths_foo"] Nothing Nothing Nothing `shouldBe` (["Foo", "Paths_foo"], [], [])
+        let exposed = ModuleSpecification ["Foo", "Paths_foo"] Nothing
+            other = ModuleSpecification Nothing Nothing
+        determineModules ["Paths_foo"] [] exposed other `shouldBe` (["Foo", "Paths_foo"], [], [])
 
     it "includes all generated modules when exposed-modules and other-modules are Nothing" $ do
-      determineModules ["Paths_foo"] [] Nothing ["ABC"] Nothing ["XYZ"] `shouldBe` (["ABC"], ["Paths_foo", "XYZ"], ["XYZ", "ABC"])
+      let exposed = ModuleSpecification Nothing ["ABC"]
+          other = ModuleSpecification Nothing ["XYZ"]
+      determineModules ["Paths_foo"] [] exposed other `shouldBe` (["ABC"], ["Paths_foo", "XYZ"], ["XYZ", "ABC"])
 
-    it "includes all generated modules when given explicit exposed-modules" $
-      determineModules ["Paths_foo"] [] ["Foo"] ["ABC"] Nothing ["XYZ"] `shouldBe` (["Foo", "ABC"], ["Paths_foo", "XYZ"], ["XYZ", "ABC"])
+    it "includes all generated modules when given explicit exposed-modules" $ do
+      let exposed = ModuleSpecification ["Foo"] ["ABC"]
+          other = ModuleSpecification Nothing ["XYZ"]
+      determineModules ["Paths_foo"] [] exposed other `shouldBe` (["Foo", "ABC"], ["Paths_foo", "XYZ"], ["XYZ", "ABC"])
 
-    it "includes all generated modules when given explicit exposed-modules and other-modules" $
-      determineModules ["Paths_foo"] [] ["Foo"] ["ABC"] ["Internal"] ["XYZ"] `shouldBe` (["Foo", "ABC"], ["Internal", "XYZ"], ["XYZ", "ABC"])
+    it "includes all generated modules when given explicit exposed-modules and other-modules" $ do
+      let exposed = ModuleSpecification ["Foo"] ["ABC"]
+          other = ModuleSpecification ["Internal"] ["XYZ"]
+      determineModules ["Paths_foo"] [] exposed other `shouldBe` (["Foo", "ABC"], ["Internal", "XYZ"], ["XYZ", "ABC"])
 
-    it "includes all generated modules when given explicit other-modules" $
-      determineModules ["Paths_foo"] [] Nothing ["ABC"] ["Internal"] ["XYZ"] `shouldBe` (["ABC"], ["Internal", "XYZ"], ["XYZ", "ABC"])
+    it "includes all generated modules when given explicit other-modules" $ do
+      let exposed = ModuleSpecification Nothing ["ABC"]
+          other = ModuleSpecification ["Internal"] ["XYZ"]
+      determineModules ["Paths_foo"] [] exposed other `shouldBe` (["ABC"], ["Internal", "XYZ"], ["XYZ", "ABC"])
 
   describe "fromLibrarySectionInConditional" $ do
     let

--- a/test/Hpack/RunSpec.hs
+++ b/test/Hpack/RunSpec.hs
@@ -11,7 +11,7 @@ import           Hpack.Render
 import           Hpack.Run
 
 library :: Library
-library = Library Nothing [] [] [] []
+library = Library Nothing [] [] [] [] []
 
 renderEmptySection :: Empty -> [Element]
 renderEmptySection Empty = []
@@ -159,7 +159,7 @@ spec = do
           ]
 
       it "retains section field order" $ do
-        renderPackage defaultRenderSettings 0 [] [("executable foo", ["default-language", "main-is", "ghc-options"])] package {packageExecutables = Map.fromList [("foo", (section $ Executable (Just "Main.hs") []) {sectionGhcOptions = ["-Wall", "-Werror"]})]} `shouldBe` unlines [
+        renderPackage defaultRenderSettings 0 [] [("executable foo", ["default-language", "main-is", "ghc-options"])] package {packageExecutables = Map.fromList [("foo", (section $ Executable (Just "Main.hs") [] []) {sectionGhcOptions = ["-Wall", "-Werror"]})]} `shouldBe` unlines [
             "name: foo"
           , "version: 0.0.0"
           , "build-type: Simple"
@@ -171,10 +171,9 @@ spec = do
           , "  ghc-options: -Wall -Werror"
           ]
 
-
     context "when rendering executable section" $ do
       it "includes dependencies" $ do
-        renderPackage_ package {packageExecutables = Map.fromList [("foo", (section $ Executable (Just "Main.hs") []) {sectionDependencies = Dependencies $ Map.fromList
+        renderPackage_ package {packageExecutables = Map.fromList [("foo", (section $ Executable (Just "Main.hs") [] []) {sectionDependencies = Dependencies $ Map.fromList
         [("foo", VersionRange "== 0.1.0"), ("bar", AnyVersion)]})]} `shouldBe` unlines [
             "name: foo"
           , "version: 0.0.0"
@@ -190,7 +189,7 @@ spec = do
           ]
 
       it "includes GHC options" $ do
-        renderPackage_ package {packageExecutables = Map.fromList [("foo", (section $ Executable (Just "Main.hs") []) {sectionGhcOptions = ["-Wall", "-Werror"]})]} `shouldBe` unlines [
+        renderPackage_ package {packageExecutables = Map.fromList [("foo", (section $ Executable (Just "Main.hs") [] []) {sectionGhcOptions = ["-Wall", "-Werror"]})]} `shouldBe` unlines [
             "name: foo"
           , "version: 0.0.0"
           , "build-type: Simple"
@@ -203,7 +202,7 @@ spec = do
           ]
 
       it "includes frameworks" $ do
-        renderPackage_ package {packageExecutables = Map.fromList [("foo", (section $ Executable (Just "Main.hs") []) {sectionFrameworks = ["foo", "bar"]})]} `shouldBe` unlines [
+        renderPackage_ package {packageExecutables = Map.fromList [("foo", (section $ Executable (Just "Main.hs") [] []) {sectionFrameworks = ["foo", "bar"]})]} `shouldBe` unlines [
             "name: foo"
           , "version: 0.0.0"
           , "build-type: Simple"
@@ -218,7 +217,7 @@ spec = do
           ]
 
       it "includes extra-framework-dirs" $ do
-        renderPackage_ package {packageExecutables = Map.fromList [("foo", (section $ Executable (Just "Main.hs") []) {sectionExtraFrameworksDirs = ["foo", "bar"]})]} `shouldBe` unlines [
+        renderPackage_ package {packageExecutables = Map.fromList [("foo", (section $ Executable (Just "Main.hs") [] []) {sectionExtraFrameworksDirs = ["foo", "bar"]})]} `shouldBe` unlines [
             "name: foo"
           , "version: 0.0.0"
           , "build-type: Simple"
@@ -233,7 +232,7 @@ spec = do
           ]
 
       it "includes GHC profiling options" $ do
-        renderPackage_ package {packageExecutables = Map.fromList [("foo", (section $ Executable (Just "Main.hs") []) {sectionGhcProfOptions = ["-fprof-auto", "-rtsopts"]})]} `shouldBe` unlines [
+        renderPackage_ package {packageExecutables = Map.fromList [("foo", (section $ Executable (Just "Main.hs") [] []) {sectionGhcProfOptions = ["-fprof-auto", "-rtsopts"]})]} `shouldBe` unlines [
             "name: foo"
           , "version: 0.0.0"
           , "build-type: Simple"


### PR DESCRIPTION
These will populate other/exposed-modules as well as
autogen-modules. Testing has revealed that Paths_* does not have to be
listed as a generated module - which is just as well, since using
autogen-modules forces cabal-version >= 2.0.

Closes #207.