### PR TITLE
Add quotes around values with spaces #237

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## next (0.21.2)
   - New top-level field: `extra-doc-files`.
+  - Add quotes around values with spaces in them (see #237)
 
 ## Changes in 0.21.1
   - Allow dependency constraints to be numbers (see #234)

--- a/src/Hpack/Render.hs
+++ b/src/Hpack/Render.hs
@@ -24,6 +24,7 @@ module Hpack.Render (
 #endif
 ) where
 
+import           Data.Char (isSpace)
 import           Data.String
 import           Data.List
 
@@ -79,9 +80,13 @@ renderField settings@RenderSettings{..} nesting name value = case renderValue se
 renderValue :: RenderSettings -> Value -> Lines
 renderValue RenderSettings{..} v = case v of
   Literal s -> SingleLine s
-  WordList ws -> SingleLine $ unwords ws
+  WordList ws -> SingleLine $ unwords $ map quote ws
   LineSeparatedList xs -> renderLineSeparatedList renderSettingsCommaStyle xs
   CommaSeparatedList xs -> renderCommaSeparatedList renderSettingsCommaStyle xs
+  where
+    quote s
+      | any isSpace s = concat ["\"", s, "\""]
+      | otherwise = s
 
 renderLineSeparatedList :: CommaStyle -> [String] -> Lines
 renderLineSeparatedList style = MultipleLines . map (padding ++)

--- a/src/Hpack/Util.hs
+++ b/src/Hpack/Util.hs
@@ -61,7 +61,7 @@ type LdOption = String
 parseMain :: String -> (FilePath, [GhcOption])
 parseMain main = case reverse name of
   x : _ | isQualifiedIdentifier name && x `notElem` ["hs", "lhs"] -> (intercalate "/" (init name) ++ ".hs", ["-main-is " ++ main])
-  _ | isModule name -> (intercalate "/" name ++ ".hs", ["-main-is " ++ main])
+  _ | isModule name -> (intercalate "/" name ++ ".hs", ["-main-is", main])
   _ -> (main, [])
   where
     name = splitOn '.' main

--- a/test/Hpack/UtilSpec.hs
+++ b/test/Hpack/UtilSpec.hs
@@ -26,10 +26,10 @@ spec = do
       parseMain "Main.lhs" `shouldBe` ("Main.lhs", [])
 
     it "accepts module" $ do
-      parseMain "Foo" `shouldBe` ("Foo.hs", ["-main-is Foo"])
+      parseMain "Foo" `shouldBe` ("Foo.hs", ["-main-is", "Foo"])
 
     it "accepts hierarchical module" $ do
-      parseMain "Foo.Bar.Baz" `shouldBe` ("Foo/Bar/Baz.hs", ["-main-is Foo.Bar.Baz"])
+      parseMain "Foo.Bar.Baz" `shouldBe` ("Foo/Bar/Baz.hs", ["-main-is", "Foo.Bar.Baz"])
 
     it "accepts qualified identifier" $ do
       parseMain "Foo.bar" `shouldBe` ("Foo.hs", ["-main-is Foo.bar"])


### PR DESCRIPTION
I'm not convinced this is the best way to solve this, but wanted to open the PR to get feedback. Three potential issues I can see:

* I'm using a simple blacklist of space characters; should we instead whitelist characters which do not require quoting?
* Do we need to also add logic for escaping values. For example, what should we do if one of the options itself contains a quote inside? I'm not familiar with the cabal format escaping rules here
* Is it OK to apply this logic to all examples of `WordList`?