### PR TITLE
Implement Infer signatures

### DIFF
--- a/src/Hpack/Util.hs
+++ b/src/Hpack/Util.hs
@@ -13,6 +13,7 @@ module Hpack.Util (
 , parseMain
 , toModule
 , getModuleFilesRecursive
+, getHsigFiles
 , tryReadFile
 , expandGlobs
 , sort
@@ -104,6 +105,15 @@ getModuleFilesRecursive baseDir = go []
       where
         pathTo :: [FilePath] -> FilePath
         pathTo p = baseDir </> joinPath p
+
+getHsigFiles :: FilePath -> IO (Maybe [String])
+getHsigFiles baseDir = do
+  hsigFiles <- filter (\filename -> ".hsig" `isSuffixOf` filename && filename `notElem` [".", ".."]) <$> getDirectoryContents baseDir
+  return $
+    if null hsigFiles then
+      Nothing
+    else
+      Just hsigFiles
 
 tryReadFile :: FilePath -> IO (Maybe String)
 tryReadFile file = do

--- a/test/EndToEndSpec.hs
+++ b/test/EndToEndSpec.hs
@@ -236,6 +236,32 @@ spec = around_ (inTempDirectoryNamed "foo") $ do
               Foo
           |]) {packageCabalVersion = ">= 2.0"}
 
+        it "specify overwrite signatures" $ do
+          touch "Foo.hsig"
+          touch "Bar.hsig"
+          [i|
+          library:
+            signatures: Baz
+          |] `shouldRenderTo` (library [i|
+          other-modules:
+              Paths_foo
+          signatures:
+              Baz
+          |]) {packageCabalVersion = ">= 2.0"}
+
+        it "lookup for .hsig files" $ do
+          touch "Foo.hsig"
+          touch "Bar.hsig"
+          [i|
+          library: {}
+          |] `shouldRenderTo` (library [i|
+          other-modules:
+              Paths_foo
+          signatures:
+              Bar
+            , Foo
+          |]) {packageCabalVersion = ">= 2.0"}
+
         it "accepts global c-sources" $ do
           [i|
           c-sources: cbits/*.c

--- a/test/Hpack/RunSpec.hs
+++ b/test/Hpack/RunSpec.hs
@@ -129,6 +129,33 @@ spec = do
         , "  default-language: Haskell2010"
         ]
 
+    it "includes signature" $ do
+      renderPackage_ package {packageLibrary = Just (section (library {librarySignatures = ["Foo"]}))} `shouldBe` unlines [
+          "name: foo"
+        , "version: 0.0.0"
+        , "build-type: Simple"
+        , "cabal-version: >= 2.0"
+        , ""
+        , "library"
+        , "  signatures:"
+        , "      Foo"
+        , "  default-language: Haskell2010"
+        ]
+
+    it "includes multiple signatures" $ do
+      renderPackage_ package {packageLibrary = Just (section (library {librarySignatures = ["Foo", "Bar"]}))} `shouldBe` unlines [
+          "name: foo"
+        , "version: 0.0.0"
+        , "build-type: Simple"
+        , "cabal-version: >= 2.0"
+        , ""
+        , "library"
+        , "  signatures:"
+        , "      Foo"
+        , "    , Bar"
+        , "  default-language: Haskell2010"
+        ]
+
     context "when rendering library section" $ do
       it "renders library section" $ do
         renderPackage_ package {packageLibrary = Just $ section library} `shouldBe` unlines [

--- a/test/Hpack/UtilSpec.hs
+++ b/test/Hpack/UtilSpec.hs
@@ -6,6 +6,7 @@ import           Data.Aeson
 import           Data.Aeson.Types
 import           Helper
 import           System.Directory
+import           Data.Maybe
 
 import           Hpack.Util
 
@@ -68,6 +69,15 @@ spec = do
         inTempDirectory $ do
           touch "foo/bar/baz"
           getModuleFilesRecursive "foo" `shouldReturn` empty
+
+  describe "getHsigFiles" $ do
+    it "lookup for *.hsig files" $ do
+      inTempDirectory $ do
+        touch "foo/bar.hsig"
+        touch "foo/baz.hsig"
+        touch "foo/foo"
+        actual <- fromJust <$> getHsigFiles "foo"
+        actual `shouldMatchList` ["bar.hsig", "baz.hsig"]
 
   describe "List" $ do
     let


### PR DESCRIPTION
@sol Sorry, I'm late.

Ref to [#239](https://github.com/sol/hpack/issues/239).

How to determine signatures precedence.

1. specify `signature` field in `package.yaml`
2. lookup `.hsig` files if not specify `signature` in `package.yaml`
3. Nothing if not exist `.hsig` file.