### PR TITLE
Set cabal-version to >= 1.18 when using extra-doc-files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## next
   - Add `--numeric-version`
   - Add support for `signatures`
+  - `extra-doc-files` requires setting `cabal-version` to at least
+    1.18; this is now done properly.
 
 ## Changes in 0.21.2
   - Fix a bug in module inference for conditionals (see #236)

--- a/src/Hpack/Run.hs
+++ b/src/Hpack/Run.hs
@@ -137,9 +137,11 @@ renderPackage settings alignment existingFieldOrder sectionsFieldOrder Package{.
       ]
      where
       packageCabalVersion :: Maybe Version
-      packageCabalVersion
-        | isJust packageCustomSetup = Just (makeVersion [1,24])
-        | otherwise = Nothing
+      packageCabalVersion = maximum [
+          Nothing
+        , makeVersion [1,24] <$ packageCustomSetup
+        , makeVersion [1,18] <$ guard (not (null packageExtraDocFiles))
+        ]
 
       libraryCabalVersion :: Library -> Maybe Version
       libraryCabalVersion Library{..} = maximum [

--- a/test/EndToEndSpec.hs
+++ b/test/EndToEndSpec.hs
@@ -90,11 +90,11 @@ spec = around_ (inTempDirectoryNamed "foo") $ do
         extra-doc-files:
           - CHANGES.markdown
           - README.markdown
-        |] `shouldRenderTo` package [i|
+        |] `shouldRenderTo` (package [i|
         extra-doc-files:
             CHANGES.markdown
             README.markdown
-        |]
+        |]) {packageCabalVersion = ">= 1.18"}
 
       it "accepts glob patterns" $ do
         touch "CHANGES.markdown"
@@ -102,11 +102,11 @@ spec = around_ (inTempDirectoryNamed "foo") $ do
         [i|
         extra-doc-files:
           - "*.markdown"
-        |] `shouldRenderTo` package [i|
+        |] `shouldRenderTo` (package [i|
         extra-doc-files:
             CHANGES.markdown
             README.markdown
-        |]
+        |]) {packageCabalVersion = ">= 1.18"}
 
       it "warns if a glob pattern does not match anything" $ do
         [i|


### PR DESCRIPTION
Managed to miss this until I was investigating something else and cabal check started complaining at me!