### PR TITLE
Add verbatim as a Cabal escape hatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## next
   - Allow `version` be a numbers
   - Ignore fields that start with an underscore everywhere, not just globally
+  - Add support for `cabal` escape hatch
 
 ## Changes in 0.23.0
   - Add support for custom decoders to allow for alternate syntax (e.g. Dhall)

--- a/README.md
+++ b/README.md
@@ -281,6 +281,22 @@ Glob patterns are expanded according to the following rules:
    separators)
  - `?`, `*` and `**` do not match a `.` at the beginning of a file/directory
 
+### Passing things verbatim to Cabal
+
+Hpack is meant to be general and handle most common use cases.  However, in
+rare cases you might want to access a Cabal feature that is not (yet) supported
+by Hpack.  To accommodate for this Hpack allows you to pass things verbatim to
+cabal.  The `verbatim` field is used for that.  It is recognized top-level, in
+sections, and in conditionals.
+
+Example:
+
+```yaml
+verbatim: |
+  build-tool-depends:
+      hspec-discover:hspec-discover == 2.*
+```
+
 ### Not repeating yourself
 
 It is possible to use YAML [anchors][yaml-anchor] (`&`), [aliases][yaml-alias]

--- a/src/Hpack/Render.hs
+++ b/src/Hpack/Render.hs
@@ -34,7 +34,7 @@ data Value =
   | WordList [String]
   deriving (Eq, Show)
 
-data Element = Stanza String [Element] | Group Element Element | Field String Value
+data Element = Stanza String [Element] | Group Element Element | Field String Value | Verbatim String
   deriving (Eq, Show)
 
 data Lines = SingleLine String | MultipleLines [String]
@@ -62,6 +62,7 @@ render :: RenderSettings -> Nesting -> Element -> [String]
 render settings nesting (Stanza name elements) = indent settings nesting name : renderElements settings (succ nesting) elements
 render settings nesting (Group a b) = render settings nesting a ++ render settings nesting b
 render settings nesting (Field name value) = renderField settings nesting name value
+render settings nesting (Verbatim str) = map (indent settings nesting) (lines str)
 
 renderElements :: RenderSettings -> Nesting -> [Element] -> [String]
 renderElements settings nesting = concatMap (render settings nesting)

--- a/src/Hpack/Run.hs
+++ b/src/Hpack/Run.hs
@@ -113,6 +113,7 @@ renderPackage settings alignment existingFieldOrder sectionsFieldOrder Package{.
       , renderTests packageTests
       , renderBenchmarks packageBenchmarks
       ]
+      ++ maybe [] renderVerbatim packageVerbatim
 
     fields :: [Element]
     fields = sortFieldsBy existingFieldOrder . mapMaybe (\(name, value) -> Field name . Literal <$> value) $ [
@@ -306,8 +307,12 @@ renderSection renderSectionData Section{..} =
   , Field "pkgconfig-depends" (CommaSeparatedList sectionPkgConfigDependencies)
   , renderDependencies "build-tools" sectionBuildTools
   ]
+  ++ maybe [] renderVerbatim sectionVerbatim
   ++ maybe [] (return . renderBuildable) sectionBuildable
   ++ map (renderConditional renderSectionData) sectionConditionals
+
+renderVerbatim :: Verbatim -> [Element]
+renderVerbatim = return . Verbatim
 
 renderConditional :: (a -> [Element]) -> Conditional (Section a) -> Element
 renderConditional renderSectionData (Conditional condition sect mElse) = case mElse of

--- a/test/EndToEndSpec.hs
+++ b/test/EndToEndSpec.hs
@@ -1069,6 +1069,36 @@ spec = around_ (inTempDirectoryNamed "foo") $ do
             , "package.yaml: Ignoring unrecognized field $.when.else.when.else.baz"
             ]
 
+    describe "verbatim" $ do
+      it "is included verbatim" $ do
+        [i|
+        library:
+          verbatim: |
+            foo: 23
+            bar: 42
+        |] `shouldRenderTo` library [i|
+        other-modules:
+            Paths_foo
+        foo: 23
+        bar: 42
+        |]
+
+      context "when specified globally" $ do
+        it "is not propagated into sections" $ do
+          [i|
+          verbatim: |
+            foo: 23
+            bar: 42
+          library: {}
+          |] `shouldRenderTo` package [i|
+          library
+            other-modules:
+                Paths_foo
+            default-language: Haskell2010
+          foo: 23
+          bar: 42
+          |]
+
 run :: HasCallStack => FilePath -> String -> IO ([String], String)
 run c old = run_ c old >>= either assertFailure return
 


### PR DESCRIPTION
This is meant to provide a temporary workaround for stuff that is not (yet) supported by Hpack.

Example usage:

```yaml
verbatim: |
  build-tool-depends:
      hspec-discover:hspec-discover == 2.*
```