### PR TITLE
Automate Hackage uploads and binary releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,11 +58,12 @@ after_success:
     && gunzip github-release.gz
     && chmod +x github-release
     && if test -n "$TRAVIS_TAG"
-      ; then ./github-release upload
+      ; then stack build --copy-bins --local-bin-path .
+      && ./github-release upload
         --token "$GITHUB_TOKEN"
         --repo "$TRAVIS_REPO_SLUG"
         --tag "$TRAVIS_TAG"
-        --file "$(stack exec which hpack)"
+        --file hpack
         --name "hpack-$TRAVIS_TAG-$TRAVIS_OS_NAME"
       ; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,19 +50,20 @@ after_success:
   - > # Upload tarball to Hackage.
     mkdir -p "$HOME/.stack/upload"
     && echo "{ \"username\": \"$HACKAGE_USERNAME\", \"password\": \"$HACKAGE_PASSWORD\" }" > "$HOME/.stack/uploads/credentials.json"
-    && if test -n "$TRAVIS_TAG"; then stack upload .; fi
+    && if test "$TRAVIS_OS_NAME" = linux -a -n "$TRAVIS_TAG"
+      ; then stack upload .
+      ; fi
   - > # Upload binary to GitHub.
     curl --location https://github.com/tfausak/github-release/releases/download/1.1.3/github-release-1.1.3-linux.gz --output github-release.gz
     && gunzip github-release.gz
     && chmod +x github-release
-    && ./github-release version
     && if test -n "$TRAVIS_TAG"
       ; then ./github-release upload
         --token "$GITHUB_TOKEN"
         --repo "$TRAVIS_REPO_SLUG"
         --tag "$TRAVIS_TAG"
         --file "$(stack exec which hpack)"
-        --name "hpack-$TRAVIS_TAG-linux"
+        --name "hpack-$TRAVIS_TAG-$TRAVIS_OS_NAME"
       ; fi
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,21 @@ script:
         stack --no-terminal test --haddock --no-haddock-deps;;
     esac
 
+after_success:
+  - > # Upload binary to GitHub.
+    curl --location https://github.com/tfausak/github-release/releases/download/1.1.3/github-release-1.1.3-linux.gz --output github-release.gz
+    && gunzip github-release.gz
+    && chmod +x github-release
+    && ./github-release version
+    && if test -n "$TRAVIS_TAG"
+      ; then ./github-release upload
+        --token "$GITHUB_TOKEN"
+        --repo "$TRAVIS_REPO_SLUG"
+        --tag "$TRAVIS_TAG"
+        --file "$(stack exec which hpack)"
+        --name "hpack-$TRAVIS_TAG-linux"
+      ; fi
+
 cache:
   directories:
     - $HOME/.tinc/cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,10 @@ script:
     esac
 
 after_success:
+  - > # Upload tarball to Hackage.
+    mkdir -p "$HOME/.stack/upload"
+    && echo "{ \"username\": \"$HACKAGE_USERNAME\", \"password\": \"$HACKAGE_PASSWORD\" }" > "$HOME/.stack/uploads/credentials.json"
+    && if test -n "$TRAVIS_TAG"; then stack upload .; fi
   - > # Upload binary to GitHub.
     curl --location https://github.com/tfausak/github-release/releases/download/1.1.3/github-release-1.1.3-linux.gz --output github-release.gz
     && gunzip github-release.gz

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,3 +18,17 @@ test_script:
 # The ugly echo "" hack is to avoid complaints about 0 being an invalid file
 # descriptor
 - echo "" | stack --no-terminal test
+
+on_success:
+  - > # Upload binary to GitHub.
+    curl -OutFile github-release.zip -Uri https://github.com/tfausak/github-release/releases/download/1.1.3/github-release-1.1.3-windows.zip
+    ; 7z x github-release.zip github-release.exe
+    ; if ($APPVEYOR_REPO_TAG_NAME) {
+      stack build --copy-bins --local-bin-path .
+      ; ./github-release.exe upload
+        --token $GITHUB_TOKEN
+        --repo $APPVEYOR_REPO_NAME
+        --tag $APPVEYOR_REPO_TAG_NAME
+        --file hpack.exe
+        --name hpack-$APPVEYOR_REPO_TAG_NAME-windows.exe
+    }

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: nightly-2018-01-29
+resolver: lts-10.4


### PR DESCRIPTION
This follows up on #261. It changes the Travis and AppVeyor scripts to automatically upload stuff on tags. It uploads package tarballs to Hackage from Linux builds on Travis. It also uploads binaries from Linux and macOS on Travis, and from Windows on AppVeyor.

Before merging this pull request, the CI environments need a few more environment variables:

- `$GITHUB_TOKEN`: Needed on both Travis and AppVeyor. This should be a personal access token. It doesn't need any particular scopes. You can create one here: https://github.com/settings/tokens
- `$HACKAGE_USERNAME` & `$HACKAGE_PASSWORD`: Only for Travis, and only for Linux. I'm guessing the username will be `SimonHengel` and the password is, of course, a secret. Unfortunately the password is required for uploading -- an API key won't work as far as I know. You could make a bogus Hackage account for managing the uploads. 

Unfortunately this CI stuff is super annoying to test. I haven't figured out a good way to test it, so there may be a bunch of test releases in your future 😄 