### PR TITLE
Generate valid `.cabal` files when `verbatim` is used top-level (see #280)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## next
   - Add support for `cxx-options` and `cxx-sources` (see #205)
+  - Generate valid `.cabal` files when `verbatim` is used top-level (see #280)
 
 ## Changes in 0.27.0
   - Local defaults are now resolved relative to the file they are

--- a/test/EndToEndSpec.hs
+++ b/test/EndToEndSpec.hs
@@ -1183,11 +1183,11 @@ spec = around_ (inTempDirectoryNamed "foo") $ do
             foo: 23
           library: {}
           |] `shouldRenderTo` package [i|
+          foo: 23
           library
             other-modules:
                 Paths_foo
             default-language: Haskell2010
-          foo: 23
           |]
 
       context "within a section" $ do

--- a/test/Hpack/RenderSpec.hs
+++ b/test/Hpack/RenderSpec.hs
@@ -114,7 +114,6 @@ spec = do
         , "version: 0.0.0"
         , "build-type: Simple"
         , "cabal-version: >= 1.10"
-        , ""
         , "extra-source-files:"
         , "    foo"
         , "    bar"


### PR DESCRIPTION
(render top-level verbatim in-between fields and stanzas)