### PR TITLE
Desugar `^>=` for compatibility with `Cabal < 2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Next
+  - Desugar `^>=` for compatibility with `Cabal < 2` (see #213)
+
 ## Changes in 0.29.2
   - Add missing `extra-source-files` (see #302)
 

--- a/test/Hpack/Syntax/DependencySpec.hs
+++ b/test/Hpack/Syntax/DependencySpec.hs
@@ -147,6 +147,11 @@ spec = do
               hpack: 2.*
             |] `shouldDecodeTo_` Dependencies [("hpack", VersionRange "==2.*")]
 
+          it "accepts ^>=" $ do
+            [yaml|
+              hpack: ^>= 1.2.3.4
+            |] `shouldDecodeTo_` Dependencies [("hpack", VersionRange ">=1.2.3.4 && <1.3")]
+
           it "reports parse errors" $ do
             [yaml|
               hpack: foo


### PR DESCRIPTION
(see #213)