### PR TITLE
Extend build-tools so that it subsumes Cabal's build-tools and build-tool-depends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
   - Warn on duplicate fields (see #283)
   - Always render `cabal-version` as `x.y` instead of `>= x.y` so that `cabal
     check` does not complain (see #322)
+  - Extend `build-tools` so that it subsumes Cabal's `build-tools` and
+    `build-tool-depends` (see #254)
 
 ## Changes in 0.29.7
   - Expose more stuff from `Hpack.Yaml` so that it can be used by third parties

--- a/README.md
+++ b/README.md
@@ -179,8 +179,48 @@ values are merged with per section values.
 | `ld-options` | · | | |
 | `dependencies` | `build-depends` | | |
 | `pkg-config-dependencies` | `pkgconfig-depends` | | |
-| `build-tools` | · | | |
+| `build-tools` | [`build-tools`](https://www.haskell.org/cabal/users-guide/developing-packages.html#pkg-field-build-tools) and/or [`build-tool-depends`](https://www.haskell.org/cabal/users-guide/developing-packages.html#pkg-field-build-tool-depends) | | |
 | `when` | | | Accepts a list of conditionals (see [Conditionals](#conditionals)) |
+
+**`build-tools`: A set of Haskell executables that are needed to build this component**
+
+Each element consists of a *name* and an optional *version constraint*.
+
+The name can be specified in two ways:
+
+1. Qualified: `<package>:<executable>`
+1. Unqualified: `<executable>`
+
+A qualified name refers to an executable named `<executable>` from a
+package named `<package>`.
+
+An unqualified name either refers to an executables in the same package, or if
+no such executable exists it is desugared to `<executable>:<executable>`.
+
+`build-tools` can be specified as a list or a mapping.
+
+Examples:
+```yaml
+build-tools:
+  - alex
+  - happy:happy
+  - hspec-discover == 2.*
+```
+```
+build-tools:
+  alex: 3.2.*
+  happy:happy: 1.19.*
+  hspec-discover: 2.*
+```
+
+When generating a `.cabal` file each element of `build-tools` is either added
+to `build-tools` or `build-tool-depends`.
+
+If the name refers to one of `alex`, `c2hs`, `cpphs`, `greencard`, `haddock`,
+`happy`, `hsc2hs` or `hscolour` then the element is added to `build-tools`,
+otherwise it is added to `build-tool-depends`.
+
+This is done to allow compatibility with a wider range of `Cabal` versions.
 
 #### <a name="library-fields"></a>Library fields
 

--- a/hpack.cabal
+++ b/hpack.cabal
@@ -4,10 +4,10 @@ cabal-version: >= 1.10
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 1641525d1e2f9399f376458c17314e181f70af5118b3678ee5f717e8760f1e08
+-- hash: a1136b4a83bc50abf6e1fac6ef221b3df0c837b248aa357568449996e9d20078
 
 name:           hpack
-version:        0.29.7
+version:        0.30.0
 synopsis:       A modern format for Haskell packages
 description:    See README at <https://github.com/sol/hpack#readme>
 category:       Development
@@ -68,6 +68,7 @@ library
       Hpack.Options
       Hpack.Render.Dsl
       Hpack.Render.Hints
+      Hpack.Syntax.BuildTools
       Hpack.Syntax.Defaults
       Hpack.Syntax.Dependency
       Hpack.Syntax.DependencyVersion
@@ -163,6 +164,7 @@ test-suite spec
       Hpack.Render.DslSpec
       Hpack.Render.HintsSpec
       Hpack.RenderSpec
+      Hpack.Syntax.BuildToolsSpec
       Hpack.Syntax.DefaultsSpec
       Hpack.Syntax.DependencySpec
       Hpack.Syntax.GitSpec
@@ -183,6 +185,7 @@ test-suite spec
       Hpack.Render
       Hpack.Render.Dsl
       Hpack.Render.Hints
+      Hpack.Syntax.BuildTools
       Hpack.Syntax.Defaults
       Hpack.Syntax.Dependency
       Hpack.Syntax.DependencyVersion

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: hpack
-version: 0.29.7
+version: 0.30.0
 synopsis: A modern format for Haskell packages
 description: See README at <https://github.com/sol/hpack#readme>
 maintainer: Simon Hengel <sol@typeful.net>

--- a/src/Hpack/Syntax/BuildTools.hs
+++ b/src/Hpack/Syntax/BuildTools.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ViewPatterns #-}
+module Hpack.Syntax.BuildTools (
+  BuildTools(..)
+, ParseBuildTool(..)
+) where
+
+import           Data.Text (Text)
+import qualified Data.Text as T
+import           Data.Semigroup (Semigroup(..))
+import           Data.Bifunctor
+import           Control.Applicative
+import qualified Distribution.Package as D
+import qualified Data.Map.Lazy as Map
+
+import qualified Distribution.Types.ExeDependency as D
+import qualified Distribution.Types.UnqualComponentName as D
+
+import           Data.Aeson.Config.FromValue
+
+import           Hpack.Syntax.DependencyVersion
+import           Hpack.Syntax.Dependency (parseDependency)
+
+newtype BuildTools = BuildTools {
+  unBuildTools :: [(ParseBuildTool, DependencyVersion)]
+} deriving (Show, Eq, Semigroup, Monoid)
+
+data ParseBuildTool = QualifiedBuildTool String String | UnqualifiedBuildTool String
+  deriving (Show, Eq)
+
+instance FromValue BuildTools where
+  fromValue v = case v of
+    String s -> BuildTools . return <$> buildToolFromString s
+    Array xs -> BuildTools <$> parseArray buildToolFromValue xs
+    Object _ -> BuildTools . map (first nameToBuildTool) . Map.toList <$> fromValue v
+    _ -> typeMismatch "Array, Object, or String" v
+
+nameToBuildTool :: String -> ParseBuildTool
+nameToBuildTool name = case break (== ':') name of
+  (executable, "") -> UnqualifiedBuildTool executable
+  (package, executable) -> QualifiedBuildTool package (drop 1 executable)
+
+buildToolFromValue :: Value -> Parser (ParseBuildTool, DependencyVersion)
+buildToolFromValue v = case v of
+  String s -> buildToolFromString s
+  Object o -> sourceDependency o
+  _ -> typeMismatch "Object or String" v
+  where
+    sourceDependency o = (,) <$> (nameToBuildTool <$> name) <*> (SourceDependency <$> fromValue v)
+      where
+        name :: Parser String
+        name = o .: "name"
+
+buildToolFromString :: Text -> Parser (ParseBuildTool, DependencyVersion)
+buildToolFromString s = parseQualifiedBuildTool s <|> parseUnqualifiedBuildTool s
+
+parseQualifiedBuildTool :: Monad m => Text -> m (ParseBuildTool, DependencyVersion)
+parseQualifiedBuildTool = fmap f . cabalParse "build tool" . T.unpack
+  where
+    f :: D.ExeDependency -> (ParseBuildTool, DependencyVersion)
+    f (D.ExeDependency package executable version) = (
+        QualifiedBuildTool (D.unPackageName package) (D.unUnqualComponentName executable)
+      , dependencyVersionFromCabal version
+      )
+
+parseUnqualifiedBuildTool :: Monad m => Text -> m (ParseBuildTool, DependencyVersion)
+parseUnqualifiedBuildTool = fmap (first UnqualifiedBuildTool) . parseDependency "build tool"

--- a/src/Hpack/Syntax/Dependency.hs
+++ b/src/Hpack/Syntax/Dependency.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE TypeFamilies #-}
 module Hpack.Syntax.Dependency (
   Dependencies(..)
+, parseDependency
 ) where
 
 import           Data.Text (Text)

--- a/test/Hpack/ConfigSpec.hs
+++ b/test/Hpack/ConfigSpec.hs
@@ -25,6 +25,7 @@ import           Data.Either
 import qualified Data.Map.Lazy as Map
 
 import           Hpack.Syntax.Dependency
+import           Hpack.Syntax.BuildTools
 import           Hpack.Config hiding (package)
 import qualified Hpack.Config as Config
 
@@ -157,6 +158,30 @@ spec = do
         touch (dir </> "Foo.hs")
         touch (dir </> "Setup.hs")
         getModules dir  "./." `shouldReturn` ["Foo"]
+
+  describe "toBuildTool" $ do
+    let toBuildTool_ = toBuildTool "my-package" ["foo"]
+    context "with an UnqualifiedBuildTool" $ do
+      context "when name does not match a local executable" $ do
+        it "returns a BuildTool" $ do
+          toBuildTool_ (UnqualifiedBuildTool "bar") `shouldBe` BuildTool "bar" "bar"
+
+      context "when name matches a local executable" $ do
+        it "returns a LocalBuildTool" $ do
+          toBuildTool_ (UnqualifiedBuildTool "foo") `shouldBe` LocalBuildTool "foo"
+
+    context "with a QualifiedBuildTool" $ do
+      context "when only package matches the current package" $ do
+        it "returns a BuildTool" $ do
+          toBuildTool_ (QualifiedBuildTool "my-package" "bar") `shouldBe` BuildTool "my-package" "bar"
+
+      context "when only executable matches a local executable" $ do
+        it "returns a BuildTool" $ do
+          toBuildTool_ (QualifiedBuildTool "other-package" "foo") `shouldBe` BuildTool "other-package" "foo"
+
+      context "when both package matches the current package and executable matches a local executable" $ do
+        it "returns a LocalBuildTool" $ do
+          toBuildTool_ (QualifiedBuildTool "my-package" "foo") `shouldBe` LocalBuildTool "foo"
 
   describe "readPackageConfig" $ do
     it "warns on missing name" $ do
@@ -401,15 +426,6 @@ spec = do
           |]
           (packageLibrary >>> (`shouldBe` Just (section library) {sectionSourceDirs = ["foo", "bar"]}))
 
-      it "accepts build-tools" $ do
-        withPackageConfig_ [i|
-          library:
-            build-tools:
-              - alex
-              - happy
-          |]
-          (packageLibrary >>> (`shouldBe` Just (section library) {sectionBuildTools = deps ["alex", "happy"]}))
-
       it "accepts default-extensions" $ do
         withPackageConfig_ [i|
           library:
@@ -436,15 +452,6 @@ spec = do
           library: {}
           |]
           (packageLibrary >>> (`shouldBe` Just (section library) {sectionSourceDirs = ["foo", "bar"]}))
-
-      it "accepts global build-tools" $ do
-        withPackageConfig_ [i|
-          build-tools:
-            - alex
-            - happy
-          library: {}
-          |]
-          (packageLibrary >>> (`shouldBe` Just (section library) {sectionBuildTools = deps ["alex", "happy"]}))
 
       it "allows to specify exposed" $ do
         withPackageConfig_ [i|
@@ -502,17 +509,6 @@ spec = do
           |]
           (packageExecutables >>> (`shouldBe` Map.fromList [("foo", (section (executable "Main.hs") {executableOtherModules = ["Paths_foo"]}) {sectionSourceDirs = ["foo", "bar"]})]))
 
-      it "accepts build-tools" $ do
-        withPackageConfig_ [i|
-          executables:
-            foo:
-              main: Main.hs
-              build-tools:
-                - alex
-                - happy
-          |]
-          (packageExecutables >>> (`shouldBe` Map.fromList [("foo", (section $ executable "Main.hs") {sectionBuildTools = deps ["alex", "happy"]})]))
-
       it "accepts global source-dirs" $ do
         withPackageConfig_ [i|
           source-dirs:
@@ -523,17 +519,6 @@ spec = do
               main: Main.hs
           |]
           (packageExecutables >>> (`shouldBe` Map.fromList [("foo", (section (executable "Main.hs") {executableOtherModules = ["Paths_foo"]}) {sectionSourceDirs = ["foo", "bar"]})]))
-
-      it "accepts global build-tools" $ do
-        withPackageConfig_ [i|
-          build-tools:
-            - alex
-            - happy
-          executables:
-            foo:
-              main: Main.hs
-          |]
-          (packageExecutables >>> (`shouldBe` Map.fromList [("foo", (section $ executable "Main.hs") {sectionBuildTools = deps ["alex", "happy"]})]))
 
       it "accepts default-extensions" $ do
         withPackageConfig_ [i|

--- a/test/Hpack/Syntax/BuildToolsSpec.hs
+++ b/test/Hpack/Syntax/BuildToolsSpec.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE OverloadedLists #-}
+module Hpack.Syntax.BuildToolsSpec (spec) where
+
+import           Helper
+
+import           Data.Aeson.Config.FromValueSpec (shouldDecodeTo_)
+
+import           Hpack.Syntax.DependencyVersion
+import           Hpack.Syntax.BuildTools
+
+spec :: Spec
+spec = do
+  describe "fromValue" $ do
+    context "when parsing BuildTools" $ do
+      context "with a scalar" $ do
+        it "accepts qualified names" $ do
+          [yaml|
+            foo:bar
+          |] `shouldDecodeTo_` BuildTools [(QualifiedBuildTool "foo" "bar", AnyVersion)]
+
+        it "accepts qualified names with a version" $ do
+          [yaml|
+            foo:bar >= 0.1.0
+          |] `shouldDecodeTo_` BuildTools [(QualifiedBuildTool "foo" "bar", VersionRange ">=0.1.0")]
+
+        it "accepts unqualified names" $ do
+          [yaml|
+            foo
+          |] `shouldDecodeTo_` BuildTools [(UnqualifiedBuildTool "foo", AnyVersion)]
+
+        it "accepts unqualified names with a version" $ do
+          [yaml|
+            foo >= 0.1.0
+          |] `shouldDecodeTo_` BuildTools [(UnqualifiedBuildTool "foo", VersionRange ">=0.1.0")]
+
+      context "with a mapping" $ do
+        it "accepts qualified names" $ do
+          [yaml|
+            foo:bar: 0.1.0
+          |] `shouldDecodeTo_` BuildTools [(QualifiedBuildTool "foo" "bar", VersionRange "==0.1.0")]
+
+        it "accepts unqualified names" $ do
+          [yaml|
+            foo: 0.1.0
+          |] `shouldDecodeTo_` BuildTools [(UnqualifiedBuildTool "foo", VersionRange "==0.1.0")]
+
+      context "with a list" $ do
+        it "accepts a list of build tools" $ do
+          [yaml|
+            - foo:one
+            - bar:two >= 0.1.0
+            - baz == 0.2.0
+          |] `shouldDecodeTo_` BuildTools [
+              (QualifiedBuildTool "foo" "one", AnyVersion)
+            , (QualifiedBuildTool "bar" "two", VersionRange ">=0.1.0")
+            , (UnqualifiedBuildTool "baz", VersionRange "==0.2.0")
+            ]
+
+        it "accepts source dependencies with a qualified name" $ do
+          let source = GitRef "https://github.com/sol/hpack" "master" Nothing
+          [yaml|
+            - name: hpack:foo
+              github: sol/hpack
+              ref: master
+          |] `shouldDecodeTo_` BuildTools [(QualifiedBuildTool "hpack" "foo", SourceDependency source)]
+
+        it "accepts source dependencies with an unqualified name" $ do
+          let source = GitRef "https://github.com/sol/hpack" "master" Nothing
+          [yaml|
+            - name: hpack
+              github: sol/hpack
+              ref: master
+          |] `shouldDecodeTo_` BuildTools [(UnqualifiedBuildTool "hpack", SourceDependency source)]


### PR DESCRIPTION
We accept both qualified names in the form of `<package>:<executable>` and unqualified names in the form of `<executable>`.  The details are in he `README`.

This is a breaking change in that system executables are not accepted as `build-tools` anymore.  https://github.com/sol/hpack/pull/313 adds support for `system-build-tools`.

In addition, packages that

- use a custom setup script that extends the list of know build tools
- take advantage of the fact that `Cabal >= 2.0` accepts arbitrary `build-tools`

might break.

To get a better understanding on how this breaking change might affect existing packages I looked at all the packages on Hackage.

The good news:
> None of the packages on Hackage that use Hpack are affected.

So this discussion is mainly about in-house packages that use `build-tools`.

What follows is a list of all `build-tools` that are used by Hackage packages (both Hpack or plain `.cabal`) together with how often they are used, grouped into three categories:

### Packages that would not break if they were using Hpack

hsc2hs: 86
c2hs: 70
alex: 65
happy: 60
cpphs: 10
hspec-discover: 7
hsx2hs: 3
cgen: 1

### Packages that would break due to a system executable if they were using Hpack

ghc: 11
git: 2
llvm-config: 2
gfortran: 1
gcc: 1
couchdb: 1
mcc: 1
nix-store: 1
nix-instantiate: 1
nix-hash: 1
nix-env: 1
nix-build: 1

### Packages that would break due to a Haskell executable if they were using Hpack

All of these would break because the executable name does not match the package name, so Hpack will require a qualified name.

gtk2hsTypeGen: 16
gtk2hsC2hs: 16
gtk2hsHookGenerator: 15
cabal: 1
grgen: 1
cgen-hs: 1

We can consider something like https://github.com/sol/hpack/pull/315 to smoothen the transition.

Opinions and feedback please!