### PR TITLE
Quote filenames generated by a glob, which have special characters (whitespace, commas) in them

### DIFF
--- a/src/Hpack/Util.hs
+++ b/src/Hpack/Util.hs
@@ -132,12 +132,7 @@ expandGlobs name dir patterns = do
     quoteSpecial :: FilePath -> FilePath
     quoteSpecial fp
       | any (\x -> isSpace x || x == ',') fp
-        = let escapeSpecial :: Char -> String
-              escapeSpecial '\n' = "\\n"
-              escapeSpecial '"'  = "\\\""
-              escapeSpecial '\\'  = "\\\\"
-              escapeSpecial x    = [x]
-          in "\"" ++ concatMap escapeSpecial fp ++ "\""
+        = show fp
       | otherwise      = fp
 
     normalize :: FilePath -> FilePath

--- a/src/Hpack/Util.hs
+++ b/src/Hpack/Util.hs
@@ -130,9 +130,12 @@ expandGlobs name dir patterns = do
           | otherwise = []
 
     quoteSpaces :: FilePath -> FilePath
-    quoteSpaces fp = if any isSpace fp
-                     then "\"" ++ fp ++ "\""
-                     else fp
+    quoteSpaces fp
+      | any isSpace fp = let escapeNewline :: Char -> String
+                             escapeNewline '\n' = "\\n"
+                             escapeNewline x    = [x]
+                         in "\"" ++ concatMap escapeNewline fp ++ "\""
+      | otherwise      = fp
 
     normalize :: FilePath -> FilePath
     normalize = toPosixFilePath . makeRelative dir

--- a/src/Hpack/Util.hs
+++ b/src/Hpack/Util.hs
@@ -131,10 +131,12 @@ expandGlobs name dir patterns = do
 
     quoteSpaces :: FilePath -> FilePath
     quoteSpaces fp
-      | any isSpace fp = let escapeNewline :: Char -> String
-                             escapeNewline '\n' = "\\n"
-                             escapeNewline x    = [x]
-                         in "\"" ++ concatMap escapeNewline fp ++ "\""
+      | any isSpace fp
+        = let escapeSpecial :: Char -> String
+              escapeSpecial '\n' = "\\n"
+              escapeSpecial '"'  = "\\\""
+              escapeSpecial x    = [x]
+          in "\"" ++ concatMap escapeSpecial fp ++ "\""
       | otherwise      = fp
 
     normalize :: FilePath -> FilePath

--- a/src/Hpack/Util.hs
+++ b/src/Hpack/Util.hs
@@ -135,6 +135,7 @@ expandGlobs name dir patterns = do
         = let escapeSpecial :: Char -> String
               escapeSpecial '\n' = "\\n"
               escapeSpecial '"'  = "\\\""
+              escapeSpecial '\\'  = "\\\\"
               escapeSpecial x    = [x]
           in "\"" ++ concatMap escapeSpecial fp ++ "\""
       | otherwise      = fp

--- a/src/Hpack/Util.hs
+++ b/src/Hpack/Util.hs
@@ -122,16 +122,16 @@ expandGlobs name dir patterns = do
     fromResult :: GlobResult -> ([String], [FilePath])
     fromResult (GlobResult pattern compiledPattern files) = case files of
       [] -> (warning, literalFile)
-      xs -> ([], map (quoteSpaces . normalize) xs)
+      xs -> ([], map (quoteSpecial . normalize) xs)
       where
         warning = [warn pattern compiledPattern]
         literalFile
           | isLiteral compiledPattern = [pattern]
           | otherwise = []
 
-    quoteSpaces :: FilePath -> FilePath
-    quoteSpaces fp
-      | any isSpace fp
+    quoteSpecial :: FilePath -> FilePath
+    quoteSpecial fp
+      | any (\x -> isSpace x || x == ',') fp
         = let escapeSpecial :: Char -> String
               escapeSpecial '\n' = "\\n"
               escapeSpecial '"'  = "\\\""

--- a/src/Hpack/Util.hs
+++ b/src/Hpack/Util.hs
@@ -122,12 +122,17 @@ expandGlobs name dir patterns = do
     fromResult :: GlobResult -> ([String], [FilePath])
     fromResult (GlobResult pattern compiledPattern files) = case files of
       [] -> (warning, literalFile)
-      xs -> ([], map normalize xs)
+      xs -> ([], map (quoteSpaces . normalize) xs)
       where
         warning = [warn pattern compiledPattern]
         literalFile
           | isLiteral compiledPattern = [pattern]
           | otherwise = []
+
+    quoteSpaces :: FilePath -> FilePath
+    quoteSpaces fp = if any isSpace fp
+                     then "\"" ++ fp ++ "\""
+                     else fp
 
     normalize :: FilePath -> FilePath
     normalize = toPosixFilePath . makeRelative dir

--- a/test/Hpack/UtilSpec.hs
+++ b/test/Hpack/UtilSpec.hs
@@ -147,17 +147,11 @@ spec = do
         expandGlobs "field-name" dir ["foo.js"] `shouldReturn` (["Specified file \"foo.js\" for field-name does not exist"], ["foo.js"])
 
     context "when a glob matches filenames with whitespace in them" $ do
-      it "quotes the filenames which have spaces in them" $ \dir -> do
+      it "quotes filenames which have spaces in them" $ \dir -> do
         touch (dir </> "foo bar baz qux.agda")
         touch (dir </> "quux quuz .agda")
         expandGlobs "file-name" dir ["*"] `shouldReturn`
           ([],["\"foo bar baz qux.agda\"", "\"quux quuz .agda\""])
-
-      it "doesn't modify filenames with no spaces in them" $ \dir -> do
-        touch (dir </> "foo-bar-baz-qux.agda")
-        touch (dir </> "quux-quuz.agda")
-        expandGlobs "file-name" dir ["*"] `shouldReturn`
-          ([],["foo-bar-baz-qux.agda", "quux-quuz.agda"])
 
       it "only modifies the filenames with spaces in them" $ \dir -> do
         touch (dir </> "foo-bar-baz-qux.agda")
@@ -184,3 +178,21 @@ spec = do
         touch (dir </> "quux quuz .ag\nda")
         expandGlobs "file-name" dir ["*"] `shouldReturn`
           ([],["\"asdf\\nqwerty.agda\"", "\"foo bar\\n baz qux.agda\"", "\"quux quuz .ag\\nda\""])
+
+      it "quotes filenames which have double quotes and whitespace in them" $ \dir -> do
+        touch (dir </> "foo\"bar\" baz\"qux.agda")
+        touch (dir </> "quux\"quuz \".agda")
+        expandGlobs "file-name" dir ["*"] `shouldReturn`
+          ([],["\"foo\\\"bar\\\" baz\\\"qux.agda\"", "\"quux\\\"quuz \\\".agda\""])
+
+      it "doesn't modify filenames with no spaces in them" $ \dir -> do
+        touch (dir </> "foo-bar-baz-qux.agda")
+        touch (dir </> "quux-quuz.agda")
+        expandGlobs "file-name" dir ["*"] `shouldReturn`
+          ([],["foo-bar-baz-qux.agda", "quux-quuz.agda"])
+
+      it "doesn't quote filenames which have double quotes but no whitespace in them" $ \dir -> do
+        touch (dir </> "foo\"bar\"baz\"qux.agda")
+        touch (dir </> "quux\"quuz\".agda")
+        expandGlobs "file-name" dir ["*"] `shouldReturn`
+          ([],["foo\"bar\"baz\"qux.agda", "quux\"quuz\".agda"])

--- a/test/Hpack/UtilSpec.hs
+++ b/test/Hpack/UtilSpec.hs
@@ -148,6 +148,12 @@ spec = do
 
     context "when a glob matches filenames with whitespace in them" $ do
       it "quotes filenames which have spaces in them" $ \dir -> do
+        touch (dir </> "foo bar baz qux.agda")
+        touch (dir </> "quux quuz .agda")
+        expandGlobs "file-name" dir ["*"] `shouldReturn`
+          ([],["\"foo bar baz qux.agda\"", "\"quux quuz .agda\""])
+
+      it "quotes filenames which have spaces and a single quote in them" $ \dir -> do
         touch (dir </> "asdf' qwerty .agda")
         touch (dir </> "foo bar baz qux.agda")
         touch (dir </> "quux quuz .agda")
@@ -159,12 +165,6 @@ spec = do
         touch (dir </> "quux quuz .agda")
         expandGlobs "file-name" dir ["*"] `shouldReturn`
           ([],["foo-bar-baz-qux.agda", "\"quux quuz .agda\""])
-
-      it "quotes filenames which have spaces in them" $ \dir -> do
-        touch (dir </> "foo bar baz qux.agda")
-        touch (dir </> "quux quuz .agda")
-        expandGlobs "file-name" dir ["*"] `shouldReturn`
-          ([],["\"foo bar baz qux.agda\"", "\"quux quuz .agda\""])
 
       it "quotes filenames which have leading and trailing whitespace" $ \dir -> do
         touch (dir </> "\nasdfqwerty.agda")

--- a/test/Hpack/UtilSpec.hs
+++ b/test/Hpack/UtilSpec.hs
@@ -145,3 +145,22 @@ spec = do
     context "when a literal file does not exist" $ do
       it "warns and keeps the file" $ \dir -> do
         expandGlobs "field-name" dir ["foo.js"] `shouldReturn` (["Specified file \"foo.js\" for field-name does not exist"], ["foo.js"])
+
+    context "when a glob matches filenames with spaces in them" $ do
+      it "quotes the filenames which have spaces in them" $ \dir -> do
+        touch (dir </> "foo bar baz qux.agda")
+        touch (dir </> "quux quuz .agda")
+        expandGlobs "file-name" dir ["*"] `shouldReturn`
+          ([],["\"foo bar baz qux.agda\"", "\"quux quuz .agda\""])
+
+      it "doesn't modify filenames with no spaces in them" $ \dir -> do
+        touch (dir </> "foo-bar-baz-qux.agda")
+        touch (dir </> "quux-quuz.agda")
+        expandGlobs "file-name" dir ["*"] `shouldReturn`
+          ([],["foo-bar-baz-qux.agda", "quux-quuz.agda"])
+
+      it "only modifies the filenames with spaces in them" $ \dir -> do
+        touch (dir </> "foo-bar-baz-qux.agda")
+        touch (dir </> "quux quuz .agda")
+        expandGlobs "file-name" dir ["*"] `shouldReturn`
+          ([],["foo-bar-baz-qux.agda", "\"quux quuz .agda\""])

--- a/test/Hpack/UtilSpec.hs
+++ b/test/Hpack/UtilSpec.hs
@@ -172,7 +172,15 @@ spec = do
           ([],["\"foo bar baz qux.agda\"", "\"quux quuz .agda\""])
 
       it "quotes filenames which have leading and trailing whitespace" $ \dir -> do
+        touch (dir </> "\nasdfqwerty.agda")
         touch (dir </> "  foo bar baz qux.agda")
         touch (dir </> "quux quuz .agda    ")
         expandGlobs "file-name" dir ["*"] `shouldReturn`
-          ([],["\"  foo bar baz qux.agda\"", "\"quux quuz .agda    \""])
+          ([],["\"\\nasdfqwerty.agda\"", "\"  foo bar baz qux.agda\"", "\"quux quuz .agda    \""])
+
+      it "quotes filenames which have newlines in them" $ \dir -> do
+        touch (dir </> "asdf\nqwerty.agda")
+        touch (dir </> "foo bar\n baz qux.agda")
+        touch (dir </> "quux quuz .ag\nda")
+        expandGlobs "file-name" dir ["*"] `shouldReturn`
+          ([],["\"asdf\\nqwerty.agda\"", "\"foo bar\\n baz qux.agda\"", "\"quux quuz .ag\\nda\""])

--- a/test/Hpack/UtilSpec.hs
+++ b/test/Hpack/UtilSpec.hs
@@ -148,10 +148,11 @@ spec = do
 
     context "when a glob matches filenames with whitespace in them" $ do
       it "quotes filenames which have spaces in them" $ \dir -> do
+        touch (dir </> "asdf' qwerty .agda")
         touch (dir </> "foo bar baz qux.agda")
         touch (dir </> "quux quuz .agda")
         expandGlobs "file-name" dir ["*"] `shouldReturn`
-          ([],["\"foo bar baz qux.agda\"", "\"quux quuz .agda\""])
+          ([],["\"asdf' qwerty .agda\"", "\"foo bar baz qux.agda\"", "\"quux quuz .agda\""])
 
       it "only modifies the filenames with spaces in them" $ \dir -> do
         touch (dir </> "foo-bar-baz-qux.agda")

--- a/test/Hpack/UtilSpec.hs
+++ b/test/Hpack/UtilSpec.hs
@@ -98,7 +98,7 @@ spec = do
       touch (dir </> "foo1")
       touch (dir </> "foo2")
       touch (dir </> "foo[1,2]")
-      expandGlobs "field-name" dir ["foo[1,2]"] `shouldReturn` ([], ["foo[1,2]"])
+      expandGlobs "field-name" dir ["foo[1,2]"] `shouldReturn` ([], ["\"foo[1,2]\""])
 
     context "when expanding *" $ do
       it "expands by extension" $ \dir -> do
@@ -209,3 +209,23 @@ spec = do
         touch (dir </> "quux\\quuz\\.agda")
         expandGlobs "file-name" dir ["*"] `shouldReturn`
           ([],["foo\\bar\\baz\\qux.agda", "quux\\quuz\\.agda"])
+
+    context "when a glob matches filenames with commas in them" $ do
+      it "quotes filenames which have commas in them" $ \dir -> do
+        touch (dir </> "foo,bar,baz,qux.agda")
+        touch (dir </> "quux,quuz,.agda")
+        expandGlobs "file-name" dir ["*"] `shouldReturn`
+          ([],["\"foo,bar,baz,qux.agda\"", "\"quux,quuz,.agda\""])
+
+      it "only modifies the filenames with commas in them" $ \dir -> do
+        touch (dir </> "foo-bar-baz-qux.agda")
+        touch (dir </> "quux,quuz,.agda")
+        expandGlobs "file-name" dir ["*"] `shouldReturn`
+          ([],["foo-bar-baz-qux.agda", "\"quux,quuz,.agda\""])
+
+      it "quotes filenames which have leading and trailing commas" $ \dir -> do
+        touch (dir </> ",asdfqwerty.agda")
+        touch (dir </> ",foo,bar,baz,qux.agda,,,,")
+        touch (dir </> "quuxquuz.agda,")
+        expandGlobs "file-name" dir ["*"] `shouldReturn`
+          ([],["\",asdfqwerty.agda\"", "\",foo,bar,baz,qux.agda,,,,\"", "\"quuxquuz.agda,\""])

--- a/test/Hpack/UtilSpec.hs
+++ b/test/Hpack/UtilSpec.hs
@@ -229,3 +229,15 @@ spec = do
         touch (dir </> "quuxquuz.agda,")
         expandGlobs "file-name" dir ["*"] `shouldReturn`
           ([],["\",asdfqwerty.agda\"", "\",foo,bar,baz,qux.agda,,,,\"", "\"quuxquuz.agda,\""])
+
+    context "when a globbing unicode files" $ do
+      it "correctly escapes unicode when quotation has to be done" $ \dir -> do
+        touch (dir </> ",λλλλ.agda")
+        touch (dir </> "λ .agda")
+        expandGlobs "file-name" dir ["*"] `shouldReturn`
+          ([], ["\",\\955\\955\\955\\955.agda\"", "\"\\955 .agda\""])
+      it "doesn't escape unicode when no quotation has to be done" $ \dir -> do
+        touch (dir </> "λλλλ.agda")
+        touch (dir </> "λ.agda")
+        expandGlobs "file-name" dir ["*"] `shouldReturn`
+          ([], ["λ.agda", "λλλλ.agda"])

--- a/test/Hpack/UtilSpec.hs
+++ b/test/Hpack/UtilSpec.hs
@@ -146,7 +146,7 @@ spec = do
       it "warns and keeps the file" $ \dir -> do
         expandGlobs "field-name" dir ["foo.js"] `shouldReturn` (["Specified file \"foo.js\" for field-name does not exist"], ["foo.js"])
 
-    context "when a glob matches filenames with spaces in them" $ do
+    context "when a glob matches filenames with whitespace in them" $ do
       it "quotes the filenames which have spaces in them" $ \dir -> do
         touch (dir </> "foo bar baz qux.agda")
         touch (dir </> "quux quuz .agda")
@@ -164,3 +164,15 @@ spec = do
         touch (dir </> "quux quuz .agda")
         expandGlobs "file-name" dir ["*"] `shouldReturn`
           ([],["foo-bar-baz-qux.agda", "\"quux quuz .agda\""])
+
+      it "quotes filenames which have spaces in them" $ \dir -> do
+        touch (dir </> "foo bar baz qux.agda")
+        touch (dir </> "quux quuz .agda")
+        expandGlobs "file-name" dir ["*"] `shouldReturn`
+          ([],["\"foo bar baz qux.agda\"", "\"quux quuz .agda\""])
+
+      it "quotes filenames which have leading and trailing whitespace" $ \dir -> do
+        touch (dir </> "  foo bar baz qux.agda")
+        touch (dir </> "quux quuz .agda    ")
+        expandGlobs "file-name" dir ["*"] `shouldReturn`
+          ([],["\"  foo bar baz qux.agda\"", "\"quux quuz .agda    \""])

--- a/test/Hpack/UtilSpec.hs
+++ b/test/Hpack/UtilSpec.hs
@@ -186,6 +186,12 @@ spec = do
         expandGlobs "file-name" dir ["*"] `shouldReturn`
           ([],["\"foo\\\"bar\\\" baz\\\"qux.agda\"", "\"quux\\\"quuz \\\".agda\""])
 
+      it "quotes filenames which have backslashes and whitespace in them" $ \dir -> do
+        touch (dir </> "foo\\bar\\ baz\\qux.agda")
+        touch (dir </> "quux\\quuz \\.agda")
+        expandGlobs "file-name" dir ["*"] `shouldReturn`
+          ([],["\"foo\\\\bar\\\\ baz\\\\qux.agda\"", "\"quux\\\\quuz \\\\.agda\""])
+
       it "doesn't modify filenames with no spaces in them" $ \dir -> do
         touch (dir </> "foo-bar-baz-qux.agda")
         touch (dir </> "quux-quuz.agda")
@@ -197,3 +203,9 @@ spec = do
         touch (dir </> "quux\"quuz\".agda")
         expandGlobs "file-name" dir ["*"] `shouldReturn`
           ([],["foo\"bar\"baz\"qux.agda", "quux\"quuz\".agda"])
+
+      it "doesn't quote filenames which have backslashes but no whitespace in them" $ \dir -> do
+        touch (dir </> "foo\\bar\\baz\\qux.agda")
+        touch (dir </> "quux\\quuz\\.agda")
+        expandGlobs "file-name" dir ["*"] `shouldReturn`
+          ([],["foo\\bar\\baz\\qux.agda", "quux\\quuz\\.agda"])


### PR DESCRIPTION
This is in relation to #350.

I also tried to escape the spaces or to use single quotes, but cabal doesn't like either of those.