### PR TITLE
Switch reexported-modules to comma-separated list

### DIFF
--- a/src/Hpack/Render.hs
+++ b/src/Hpack/Render.hs
@@ -306,7 +306,7 @@ renderGeneratedModules :: [String] -> Element
 renderGeneratedModules = Field "autogen-modules" . LineSeparatedList
 
 renderReexportedModules :: [String] -> Element
-renderReexportedModules = Field "reexported-modules" . LineSeparatedList
+renderReexportedModules = Field "reexported-modules" . CommaSeparatedList
 
 renderSignatures :: [String] -> Element
 renderSignatures = Field "signatures" . CommaSeparatedList


### PR DESCRIPTION
`reexported-modules` items can contain spaces, so [Cabal requires commas](https://github.com/haskell/cabal/issues/5713#issuecomment-441359672).