### PR TITLE
GHC 8.8 compatibility

### DIFF
--- a/src/Data/Aeson/Config/Parser.hs
+++ b/src/Data/Aeson/Config/Parser.hs
@@ -61,7 +61,7 @@ fromAesonPathElement e = case e of
   Aeson.Index n -> Index n
 
 newtype Parser a = Parser {unParser :: WriterT (Set JSONPath) Aeson.Parser a}
-  deriving (Functor, Applicative, Alternative, Monad)
+  deriving (Functor, Applicative, Alternative, Monad, MonadFail)
 
 liftParser :: Aeson.Parser a -> Parser a
 liftParser = Parser . lift

--- a/src/Hpack/Config.hs
+++ b/src/Hpack/Config.hs
@@ -12,6 +12,8 @@
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LiberalTypeSynonyms #-}
+
 module Hpack.Config (
 -- | /__NOTE:__/ This module is exposed to allow integration of Hpack into
 -- other tools.  It is not meant for general use by end users.  The following

--- a/src/Hpack/Syntax/BuildTools.hs
+++ b/src/Hpack/Syntax/BuildTools.hs
@@ -53,7 +53,7 @@ instance FromValue BuildTools where
       buildToolFromString :: Text -> Parser (ParseBuildTool, DependencyVersion)
       buildToolFromString s = parseQualifiedBuildTool s <|> parseUnqualifiedBuildTool s
 
-      parseQualifiedBuildTool :: Monad m => Text -> m (ParseBuildTool, DependencyVersion)
+      parseQualifiedBuildTool :: MonadFail m => Text -> m (ParseBuildTool, DependencyVersion)
       parseQualifiedBuildTool = fmap fromCabal . cabalParse "build tool" . T.unpack
         where
           fromCabal :: D.ExeDependency -> (ParseBuildTool, DependencyVersion)
@@ -62,7 +62,7 @@ instance FromValue BuildTools where
             , DependencyVersion Nothing $ versionConstraintFromCabal version
             )
 
-      parseUnqualifiedBuildTool :: Monad m => Text -> m (ParseBuildTool, DependencyVersion)
+      parseUnqualifiedBuildTool :: MonadFail m => Text -> m (ParseBuildTool, DependencyVersion)
       parseUnqualifiedBuildTool = fmap (first UnqualifiedBuildTool) . parseDependency "build tool"
 
 newtype SystemBuildTools = SystemBuildTools {
@@ -80,7 +80,7 @@ instance FromValue SystemBuildTools where
       , parseName = T.unpack
       }
 
-      parseSystemBuildTool :: Monad m => Text -> m (String, VersionConstraint)
+      parseSystemBuildTool :: MonadFail m => Text -> m (String, VersionConstraint)
       parseSystemBuildTool = fmap fromCabal . cabalParse "system build tool" . T.unpack
         where
           fromCabal :: D.LegacyExeDependency -> (String, VersionConstraint)

--- a/src/Hpack/Syntax/Dependencies.hs
+++ b/src/Hpack/Syntax/Dependencies.hs
@@ -59,7 +59,7 @@ objectDependencyInfo o = objectDependency o >>= addMixins o
 dependencyInfo :: Value -> Parser DependencyInfo
 dependencyInfo = withDependencyVersion (DependencyInfo []) addMixins
 
-parseDependency :: Monad m => String -> Text -> m (String, DependencyVersion)
+parseDependency :: MonadFail m => String -> Text -> m (String, DependencyVersion)
 parseDependency subject = fmap fromCabal . cabalParse subject . T.unpack
   where
     fromCabal :: D.Dependency -> (String, DependencyVersion)

--- a/src/Hpack/Syntax/DependencyVersion.hs
+++ b/src/Hpack/Syntax/DependencyVersion.hs
@@ -133,13 +133,13 @@ scientificToVersion n = version
       | otherwise = 0
     e = base10Exponent n
 
-parseVersionRange :: Monad m => String -> m VersionConstraint
+parseVersionRange :: MonadFail m => String -> m VersionConstraint
 parseVersionRange = fmap versionConstraintFromCabal . parseCabalVersionRange
 
-parseCabalVersionRange :: Monad m => String -> m D.VersionRange
+parseCabalVersionRange :: MonadFail m => String -> m D.VersionRange
 parseCabalVersionRange = cabalParse "constraint"
 
-cabalParse :: (Monad m, D.Parsec a) => String -> String -> m a
+cabalParse :: (MonadFail m, D.Parsec a) => String -> String -> m a
 cabalParse subject s = case D.eitherParsec s of
   Right d -> return d
   Left _ ->fail $ unwords ["invalid",  subject, show s]


### PR DESCRIPTION
GHC 8.8 compatibility.  Needed MonadFail and also `-XLiberalTypeSynonyms`

Signed-off-by: Shane Peelar <lookatyouhacker@gmail.com>