### PR TITLE
stack.yaml: update to latest nightly snapshot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,12 @@ matrix:
       compiler: ": #tinc 8.4.3"
       addons: {apt: {packages: [cabal-install-2.2,ghc-8.4.3,happy-1.19.5], sources: [hvr-ghc]}}
 
-    - env: BUILD=stack GHCVER=8.4.3 STACK_YAML=stack.yaml
-      compiler: ": #stack 8.4.3"
-      addons: {apt: {packages: [ghc-8.4.3,happy-1.19.5], sources: [hvr-ghc]}}
+    - env: BUILD=stack GHCVER=8.8.1 STACK_YAML=stack.yaml
+      compiler: ": #stack 8.8.1"
+      addons: {apt: {packages: [ghc-8.8.1,happy-1.19.5], sources: [hvr-ghc]}}
 
     - env: BUILD=stack STACK_YAML=stack.yaml RELEASE=true
-      compiler: ": #stack 8.4.3 osx"
+      compiler: ": #stack 8.8.1 osx"
       os: osx
 
 before_install:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,1 @@
-resolver: nightly-2018-12-12
-extra-deps:
-  - clock-0.8
-  - aeson-1.4.3.0
+resolver: nightly-2019-10-05


### PR DESCRIPTION
`stack` version 2.1.3.1 builds the package just fine with this simplified configuration, but the version you're using in CI seems to have trouble with ghc-8.8.1.