### PR TITLE
Implement hpack-hash feature.

### DIFF
--- a/src/Hpack/Config.hs
+++ b/src/Hpack/Config.hs
@@ -148,6 +148,7 @@ package name version = Package {
   , packageDataDir = Nothing
   , packageSourceRepository = Nothing
   , packageCustomSetup = Nothing
+  , packageHpackHash = Nothing
   , packageLibrary = Nothing
   , packageInternalLibraries = mempty
   , packageExecutables = mempty
@@ -534,6 +535,7 @@ data PackageConfig_ library executable = PackageConfig {
 , packageConfigGithub :: Maybe Text
 , packageConfigGit :: Maybe String
 , packageConfigCustomSetup :: Maybe CustomSetupSection
+, packageConfigHpackHash :: Maybe Bool
 , packageConfigLibrary :: Maybe library
 , packageConfigInternalLibraries :: Maybe (Map String library)
 , packageConfigExecutable :: Maybe executable
@@ -837,6 +839,7 @@ data Package = Package {
 , packageDataDir :: Maybe FilePath
 , packageSourceRepository :: Maybe SourceRepository
 , packageCustomSetup :: Maybe CustomSetup
+, packageHpackHash :: Maybe Bool
 , packageLibrary :: Maybe (Section Library)
 , packageInternalLibraries :: Map String (Section Library)
 , packageExecutables :: Map String (Section Executable)
@@ -1111,6 +1114,7 @@ toPackage_ dir (Product g PackageConfig{..}) = do
       , packageDataDir = packageConfigDataDir
       , packageSourceRepository = sourceRepository
       , packageCustomSetup = mCustomSetup
+      , packageHpackHash = packageConfigHpackHash
       , packageLibrary = mLibrary
       , packageInternalLibraries = internalLibraries
       , packageExecutables = executables

--- a/test/Hpack/CabalFileSpec.hs
+++ b/test/Hpack/CabalFileSpec.hs
@@ -24,6 +24,11 @@ spec = do
         writeFile file $ header "package.yaml" version (Just hash)
         readCabalFile file `shouldReturn` Just (CabalFile (Just version) (Just hash) [])
 
+    it "hpack-hash:false omits hash" $ do
+      inTempDirectory $ do
+        writeFile file $ header "package.yaml" version Nothing
+        readCabalFile file `shouldReturn` Just (CabalFile (Just version) Nothing [])
+
     it "accepts cabal-version at the beginning of the file" $ do
       inTempDirectory $ do
         writeFile file $ ("cabal-version: 2.2\n" ++ header "package.yaml" version (Just hash))

--- a/test/Hpack/CabalFileSpec.hs
+++ b/test/Hpack/CabalFileSpec.hs
@@ -21,12 +21,12 @@ spec = do
 
     it "includes hash" $ do
       inTempDirectory $ do
-        writeFile file $ header "package.yaml" version hash
+        writeFile file $ header "package.yaml" version (Just hash)
         readCabalFile file `shouldReturn` Just (CabalFile (Just version) (Just hash) [])
 
     it "accepts cabal-version at the beginning of the file" $ do
       inTempDirectory $ do
-        writeFile file $ ("cabal-version: 2.2\n" ++ header "package.yaml" version hash)
+        writeFile file $ ("cabal-version: 2.2\n" ++ header "package.yaml" version (Just hash))
         readCabalFile file `shouldReturn` Just (CabalFile (Just version) (Just hash) ["cabal-version: 2.2"])
 
   describe "extractVersion" $ do

--- a/test/HpackSpec.hs
+++ b/test/HpackSpec.hs
@@ -100,3 +100,12 @@ spec = do
               old <- readFile file
               hpack `shouldReturn` outputUnchanged
               readFile file `shouldReturn` old
+
+        context "hpack-hash: false" $ do
+          it "always generates file" $ do
+            writeFile packageConfig $ unlines [
+                "name: foo"
+              , "hpack-hash: false"
+              ]
+            hpack `shouldReturn` generated
+            hpack `shouldReturn` generated


### PR DESCRIPTION
This implements the feature request in issue #380.

I used the name `hpack-hash` to make it clear that it is a hpack feature, not a cabal one.

I am happy to change the implementation and attribute name as needed.