### PR TITLE
Add command-line options --hash and --no-hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
-## Changes in 0.34.0 (upcoming)
+## Changes in 0.34.0
+  - Use `PreferNoHash` as default `GenerateHashStrategy`
   - Add support for library `visibility` (see #382)
   - Reject URLs for `github`
+
+## Changes in 0.33.1
+  - Add `GenerateHashStrategy`.  The default is `PreferHash` for `0.33.0` and
+    will change to `PreferNoHash` with `0.34.0`. See
+    https://github.com/sol/hpack/pull/390) for details.
+
+  - Add command-line options `--hash` and `--no-hash`
+
+## Changes in 0.33.0.1
+  - Silently ignore missing hash when the cabal file content didn't change at
+    all (for forward compatibility with #390)
 
 ## Changes in 0.33.0
   - Support GHC 8.8.1: `fail` is no longer a part of `Monad`. Instead, it lives

--- a/src/Hpack/CabalFile.hs
+++ b/src/Hpack/CabalFile.hs
@@ -16,7 +16,8 @@ makeVersion :: [Int] -> Version
 makeVersion v = Version v []
 
 data CabalFile = CabalFile {
-  cabalFileHpackVersion :: Maybe Version
+  cabalFileCabalVersion :: [String]
+, cabalFileHpackVersion :: Maybe Version
 , cabalFileHash :: Maybe Hash
 , cabalFileContents :: [String]
 } deriving (Eq, Show)
@@ -25,13 +26,13 @@ readCabalFile :: FilePath -> IO (Maybe CabalFile)
 readCabalFile cabalFile = fmap parse <$> tryReadFile cabalFile
   where
     parse :: String -> CabalFile
-    parse (splitHeader -> (h, c)) = CabalFile (extractVersion h) (extractHash h) c
+    parse (splitHeader -> (cabalVersion, h, c)) = CabalFile cabalVersion (extractVersion h) (extractHash h) c
 
-    splitHeader :: String -> ([String], [String])
+    splitHeader :: String -> ([String], [String], [String])
     splitHeader (removeGitConflictMarkers . lines -> c) =
       case span (not . isComment) c of
         (cabalVersion, xs) -> case span isComment xs of
-          (header, body) -> (header, cabalVersion ++ dropWhile null body)
+          (header, body) -> (cabalVersion, header, dropWhile null body)
 
     isComment = ("--" `isPrefixOf`)
 

--- a/test/Hpack/CabalFileSpec.hs
+++ b/test/Hpack/CabalFileSpec.hs
@@ -9,8 +9,14 @@ import           Data.String.Interpolate.Util
 
 import           Paths_hpack (version)
 
+import           Hpack.Util (Hash)
+import           Data.Version (Version)
 import           Hpack (header)
+
 import           Hpack.CabalFile
+
+mkHeader :: FilePath -> Version -> Hash -> String
+mkHeader p v hash = unlines $ header p (Just v) (Just hash)
 
 spec :: Spec
 spec = do
@@ -21,13 +27,13 @@ spec = do
 
     it "includes hash" $ do
       inTempDirectory $ do
-        writeFile file $ header "package.yaml" version hash
-        readCabalFile file `shouldReturn` Just (CabalFile (Just version) (Just hash) [])
+        writeFile file $ mkHeader "package.yaml" version hash
+        readCabalFile file `shouldReturn` Just (CabalFile [] (Just version) (Just hash) [])
 
     it "accepts cabal-version at the beginning of the file" $ do
       inTempDirectory $ do
-        writeFile file $ ("cabal-version: 2.2\n" ++ header "package.yaml" version hash)
-        readCabalFile file `shouldReturn` Just (CabalFile (Just version) (Just hash) ["cabal-version: 2.2"])
+        writeFile file $ ("cabal-version: 2.2\n" ++ mkHeader "package.yaml" version hash)
+        readCabalFile file `shouldReturn` Just (CabalFile ["cabal-version: 2.2"] (Just version) (Just hash) [])
 
   describe "extractVersion" $ do
     it "extracts Hpack version from a cabal file" $ do

--- a/test/Hpack/OptionsSpec.hs
+++ b/test/Hpack/OptionsSpec.hs
@@ -18,10 +18,10 @@ spec = do
 
     context "by default" $ do
       it "returns Run" $ do
-        parseOptions defaultTarget [] `shouldReturn` Run (ParseOptions Verbose NoForce False defaultTarget)
+        parseOptions defaultTarget [] `shouldReturn` Run (ParseOptions Verbose NoForce Nothing False defaultTarget)
 
       it "includes target" $ do
-        parseOptions defaultTarget ["foo.yaml"] `shouldReturn` Run (ParseOptions Verbose NoForce False "foo.yaml")
+        parseOptions defaultTarget ["foo.yaml"] `shouldReturn` Run (ParseOptions Verbose NoForce Nothing False "foo.yaml")
 
       context "with superfluous arguments" $ do
         it "returns ParseError" $ do
@@ -29,19 +29,31 @@ spec = do
 
       context "with --silent" $ do
         it "sets optionsVerbose to NoVerbose" $ do
-          parseOptions defaultTarget ["--silent"] `shouldReturn` Run (ParseOptions NoVerbose NoForce False defaultTarget)
+          parseOptions defaultTarget ["--silent"] `shouldReturn` Run (ParseOptions NoVerbose NoForce Nothing False defaultTarget)
 
       context "with --force" $ do
         it "sets optionsForce to Force" $ do
-          parseOptions defaultTarget ["--force"] `shouldReturn` Run (ParseOptions Verbose Force False defaultTarget)
+          parseOptions defaultTarget ["--force"] `shouldReturn` Run (ParseOptions Verbose Force Nothing False defaultTarget)
 
       context "with -f" $ do
         it "sets optionsForce to Force" $ do
-          parseOptions defaultTarget ["-f"] `shouldReturn` Run (ParseOptions Verbose Force False defaultTarget)
+          parseOptions defaultTarget ["-f"] `shouldReturn` Run (ParseOptions Verbose Force Nothing False defaultTarget)
+
+      context "when determining parseOptionsHash" $ do
+
+        it "assumes True on --hash" $ do
+          parseOptions defaultTarget ["--hash"] `shouldReturn` Run (ParseOptions Verbose NoForce (Just True) False defaultTarget)
+
+        it "assumes False on --no-hash" $ do
+          parseOptions defaultTarget ["--no-hash"] `shouldReturn` Run (ParseOptions Verbose NoForce (Just False) False defaultTarget)
+
+        it "gives last occurrence precedence" $ do
+          parseOptions defaultTarget ["--no-hash", "--hash"] `shouldReturn` Run (ParseOptions Verbose NoForce (Just True) False defaultTarget)
+          parseOptions defaultTarget ["--hash", "--no-hash"] `shouldReturn` Run (ParseOptions Verbose NoForce (Just False) False defaultTarget)
 
       context "with -" $ do
         it "sets optionsToStdout to True, implies Force and NoVerbose" $ do
-          parseOptions defaultTarget ["-"] `shouldReturn` Run (ParseOptions NoVerbose Force True defaultTarget)
+          parseOptions defaultTarget ["-"] `shouldReturn` Run (ParseOptions NoVerbose Force Nothing True defaultTarget)
 
         it "rejects - for target" $ do
           parseOptions defaultTarget ["-", "-"] `shouldReturn` ParseError

--- a/test/HpackSpec.hs
+++ b/test/HpackSpec.hs
@@ -6,7 +6,6 @@ import           Prelude hiding (readFile)
 import qualified Prelude as Prelude
 
 import           Control.DeepSeq
-import           Data.List
 
 import           Hpack.Config
 import           Hpack.CabalFile
@@ -17,94 +16,139 @@ readFile name = Prelude.readFile name >>= (return $!!)
 
 spec :: Spec
 spec = do
-  describe "hpackResult" $ do
-    context "with existing cabal file" $ around_ inTempDirectory $ before_ (writeFile packageConfig "name: foo") $ do
-      let
-        file = "foo.cabal"
+  describe "header" $ do
+    it "generates header" $ do
+      header "foo.yaml" Nothing Nothing `shouldBe` [
+          "-- This file has been generated from foo.yaml by hpack."
+        , "--"
+        , "-- see: https://github.com/sol/hpack"
+        , ""
+        ]
 
-        hpackWithVersion v = hpackResultWithVersion v defaultOptions
-        hpack = hpackResult defaultOptions
-        hpackForce = hpackResult defaultOptions {optionsForce = Force}
+    context "with hpack version" $ do
+      it "includes hpack version" $ do
+        header "foo.yaml" (Just $ makeVersion [0,34,0]) Nothing `shouldBe` [
+            "-- This file has been generated from foo.yaml by hpack version 0.34.0."
+          , "--"
+          , "-- see: https://github.com/sol/hpack"
+          , ""
+          ]
 
-        generated = Result [] file Generated
-        modifiedManually = Result [] file ExistingCabalFileWasModifiedManually
-        outputUnchanged = Result [] file OutputUnchanged
-        alreadyGeneratedByNewerHpack = Result [] file AlreadyGeneratedByNewerHpack
+    context "with hash" $ do
+      it "includes hash" $ do
+        header "foo.yaml" Nothing (Just "some-hash") `shouldBe` [
+            "-- This file has been generated from foo.yaml by hpack."
+          , "--"
+          , "-- see: https://github.com/sol/hpack"
+          , "--"
+          , "-- hash: some-hash"
+          , ""
+          ]
 
-      context "when cabal file was created manually" $ do
-        it "does not overwrite existing cabal file" $ do
-          let existing = "some existing cabal file"
-          writeFile file existing
-          hpack `shouldReturn` modifiedManually
+  describe "renderCabalFile" $ do
+    it "is inverse to readCabalFile" $ do
+      expected <- lines <$> readFile "hpack.cabal"
+      Just c <- readCabalFile "hpack.cabal"
+      renderCabalFile "package.yaml" c `shouldBe` expected
+
+  describe "hpackResult" $ around_ inTempDirectory $ before_ (writeFile packageConfig "name: foo") $ do
+    let
+      file = "foo.cabal"
+
+      hpackWithVersion v = hpackResultWithVersion (makeVersion v) defaultOptions
+      hpackWithStrategy strategy = hpackResult defaultOptions { optionsGenerateHashStrategy = strategy }
+      hpackForce = hpackResult defaultOptions {optionsForce = Force}
+
+      generated = Result [] file Generated
+      modifiedManually = Result [] file ExistingCabalFileWasModifiedManually
+      outputUnchanged = Result [] file OutputUnchanged
+      alreadyGeneratedByNewerHpack = Result [] file AlreadyGeneratedByNewerHpack
+
+      modifyPackageConfig = writeFile packageConfig $ unlines [
+          "name: foo"
+        , "version: 0.1.0"
+        ]
+
+      modifyCabalFile = do
+        xs <- readFile file
+        writeFile file $ xs ++ "foo\n"
+
+      manuallyCreateCabalFile = do
+        writeFile file "some existing cabal file"
+
+      doesNotGenerateHash :: HasCallStack => GenerateHashStrategy -> Spec
+      doesNotGenerateHash strategy = do
+        it "does not generate hash" $ do
+          hpackWithStrategy strategy `shouldReturn` generated
+          readFile file >>= (`shouldNotContain` "hash")
+
+      generatesHash :: HasCallStack => GenerateHashStrategy -> Spec
+      generatesHash strategy = do
+        it "generates hash" $ do
+          hpackWithStrategy strategy `shouldReturn` generated
+          readFile file >>= (`shouldContain` "hash")
+
+      doesNotOverwrite :: HasCallStack => GenerateHashStrategy -> Spec
+      doesNotOverwrite strategy = do
+        it "does not overwrite cabal file" $ do
+          existing <- readFile file
+          hpackWithStrategy strategy `shouldReturn` modifiedManually
           readFile file `shouldReturn` existing
 
+      with strategy item = context ("with " ++ show strategy) $ item strategy
+
+    context "without an existing cabal file" $ do
+      with ForceHash generatesHash
+      with PreferHash generatesHash
+      with ForceNoHash doesNotGenerateHash
+      with PreferNoHash doesNotGenerateHash
+
+    context "with an existing cabal file" $ do
+      context "without a hash" $ before_ (hpackWithStrategy ForceNoHash >> modifyPackageConfig) $ do
+        with ForceHash generatesHash
+        with PreferHash doesNotGenerateHash
+        with ForceNoHash doesNotGenerateHash
+        with PreferNoHash doesNotGenerateHash
+
+      context "with a hash" $ before_ (hpackWithStrategy ForceHash >> modifyPackageConfig) $ do
+        with ForceHash generatesHash
+        with PreferHash generatesHash
+        with ForceNoHash doesNotGenerateHash
+        with PreferNoHash generatesHash
+
+        context "with manual modifications" $ before_ modifyCabalFile $ do
+          with ForceHash doesNotOverwrite
+          with PreferHash doesNotOverwrite
+          with ForceNoHash doesNotGenerateHash
+          with PreferNoHash doesNotOverwrite
+
+      context "when created manually" $ before_ manuallyCreateCabalFile $ do
+        with ForceHash doesNotOverwrite
+        with PreferHash doesNotOverwrite
+        with ForceNoHash doesNotOverwrite
+        with PreferNoHash doesNotOverwrite
+
         context "with --force" $ do
-          it "overwrites existing cabal file" $ do
-            _ <- hpack
-            expected <- readFile file
-            writeFile file "some existing cabal file"
+          it "overwrites cabal file" $ do
             hpackForce `shouldReturn` generated
-            readFile file `shouldReturn` expected
 
-      context "when cabal file was created with hpack < 0.20.0" $ do
-        it "overwrites existing cabal file" $ do
-          _ <- hpack
-          expected <- readFile file
-          writeFile file "-- This file has been generated from package.yaml by hpack version 0.19.3."
-          hpack `shouldReturn` generated
-          readFile file `shouldReturn` expected
+      context "when generated with a newer version of hpack" $ do
+        it "does not overwrite cabal file" $ do
+          _ <- hpackWithVersion [0,22,0]
+          old <- readFile file
+          modifyPackageConfig
+          hpackWithVersion [0,20,0] `shouldReturn` alreadyGeneratedByNewerHpack
+          readFile file `shouldReturn` old
 
-      context "when cabal file was created with hpack >= 0.20.0" $ do
-        context "when hash is missing" $ do
-          it "does not overwrite existing cabal file" $ do
-            let existing = "-- This file has been generated from package.yaml by hpack version 0.20.0."
-            writeFile file existing
-            hpack `shouldReturn` modifiedManually
-            readFile file `shouldReturn` existing
+      context "when only the hpack version in the cabal file header changed" $ do
+        it "does not overwrite cabal file" $ do
+          _ <- hpackWithVersion [0,22,0]
+          old <- readFile file
+          hpackWithVersion [0,30,0] `shouldReturn` outputUnchanged
+          readFile file `shouldReturn` old
 
-          context "when only the the cabal file header changed" $ do
-            it "does not complain if it's newer" $ do
-              hpack `shouldReturn` generated
-              let removeHash = unlines . filter (not . isInfixOf "hash") . lines
-              readFile file >>= writeFile file . removeHash
-              hpack `shouldReturn` outputUnchanged
-
-        context "when hash is present" $ do
-          context "when exsting cabal file was generated with a newer version of hpack" $ do
-            it "does not overwrite existing cabal file" $ do
-              writeFile packageConfig $ unlines [
-                  "name: foo"
-                , "version: 0.1.0"
-                ]
-              _ <- hpackWithVersion (makeVersion [0,22,0])
-              old <- readFile file
-
-              writeFile packageConfig $ unlines [
-                  "name: foo"
-                , "version: 0.2.0"
-                ]
-
-              hpackWithVersion (makeVersion [0,20,0]) `shouldReturn` alreadyGeneratedByNewerHpack
-              readFile file `shouldReturn` old
-
-          context "when cabal file was modified manually" $ do
-            it "does not overwrite existing cabal file" $ do
-              _ <- hpack
-              old <- readFile file
-              let modified = old ++ "foo\n"
-              writeFile file modified
-              _ <- hpack
-              readFile file `shouldReturn` modified
-
-          context "when only the hpack version in the cabal file header changed" $ do
-            it "does not overwrite existing cabal file" $ do
-              _ <- hpackWithVersion (makeVersion [0,20,0])
-              old <- readFile file
-              hpack `shouldReturn` outputUnchanged
-              readFile file `shouldReturn` old
-
-            it "does not complain if it's newer" $ do
-              _ <- hpackWithVersion (makeVersion [999,999,0])
-              old <- readFile file
-              hpack `shouldReturn` outputUnchanged
-              readFile file `shouldReturn` old
+        it "does not complain if it's newer" $ do
+          _ <- hpackWithVersion [0,22,0]
+          old <- readFile file
+          hpackWithVersion [0,20,0] `shouldReturn` outputUnchanged
+          readFile file `shouldReturn` old


### PR DESCRIPTION
This is an alternative proposal for #381.  It adds two new command-line flags, `--no-hash` and `--hash`.  A brief description of the semantics follows.

Conceptually, there are four different modes, of which `hpack` exposes three to the user.

### `ForceNoHash`

(enabled with `--no-hash`, implies `--force`)

- No hash will be included in the header comment of the generated cabal file

### `ForceHash`

(enabled with `--hash`, implies `--force`)

- A hash will be included in the header comment of the generated cabal file

### `PreferNoHash`

(the default behavior for `hpack`)

- When there is no existing cabal file it behaves like `ForceNoHash`
- When there is an existing cabal file the convention from that file is followed

### `PreferHash`

(not exposed, but available through the API)

- When there is no existing cabal file it behaves like `ForceHash`
- When there is an existing cabal file the convention from that file is followed