### PR TITLE
Fix #406 by nubbing module list generated from source files

### DIFF
--- a/hpack.cabal
+++ b/hpack.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           hpack
-version:        0.34.2
+version:        0.34.3
 synopsis:       A modern format for Haskell packages
 description:    See README at <https://github.com/sol/hpack#readme>
 category:       Development

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: hpack
-version: 0.34.2
+version: 0.34.3
 synopsis: A modern format for Haskell packages
 description: See README at <https://github.com/sol/hpack#readme>
 maintainer: Simon Hengel <sol@typeful.net>

--- a/src/Hpack/Module.hs
+++ b/src/Hpack/Module.hs
@@ -46,7 +46,7 @@ getModules dir src_ = sortModules <$> do
   if exists
     then do
       src <- Directory.canonicalizePath (dir </> src_)
-      removeSetup src . map toModule <$> getModuleFilesRecursive src
+      removeSetup src . nub . map toModule <$> getModuleFilesRecursive src
     else return []
   where
     removeSetup :: FilePath -> [Module] -> [Module]


### PR DESCRIPTION
Fix #406 by nubbing module list generated from source files
    
Inserting a `nub` here is strictly improving the state of affairs, since cabal chokes on a module list with duplicates.
    
This patch might also fix #353.