### PR TITLE
Remove build status from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 [![Hackage version](https://img.shields.io/hackage/v/hpack.svg?label=Hackage&color=informational)](http://hackage.haskell.org/package/hpack)
 [![Stackage LTS version](https://www.stackage.org/package/hpack/badge/lts?label=Stackage)](https://www.stackage.org/package/hpack)
 [![hpack on Stackage Nightly](https://stackage.org/package/hpack/badge/nightly)](https://stackage.org/nightly/package/hpack)
-[![Cabal build](https://github.com/sol/hpack/workflows/build/badge.svg)](https://github.com/sol/hpack/actions)
-
 
 # hpack: A modern format for Haskell packages
 


### PR DESCRIPTION
We are seeing spontanous build failures due to GH connection issues
(e.g. the checkout action fails).  There is nothing wrong with the code
so the build badge does not reliably provide useful informatin to users.