### PR TITLE
Dont't build with GHC 9.0.1 for now

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,9 +27,9 @@ jobs:
           - '8.10'
         include:
           - os: macos-latest
-            ghc: latest
+            ghc: '8.10'
           - os: windows-latest
-            ghc: latest
+            ghc: '8.10'
     steps:
       - uses: actions/checkout@v2
       - uses: haskell/actions/setup@v1


### PR DESCRIPTION
(blocked by https://github.com/tibbe/hashable/issues/193)