### PR TITLE
Add support for rts-options

### DIFF
--- a/src/Hpack/Config.hs
+++ b/src/Hpack/Config.hs
@@ -231,10 +231,11 @@ data ExecutableSection = ExecutableSection {
   executableSectionMain :: Maybe FilePath
 , executableSectionOtherModules :: Maybe (List Module)
 , executableSectionGeneratedOtherModules :: Maybe (List Module)
+, executableSectionRtsOptions :: Maybe (List String)
 } deriving (Eq, Show, Generic, FromValue)
 
 instance Monoid ExecutableSection where
-  mempty = ExecutableSection Nothing Nothing Nothing
+  mempty = ExecutableSection Nothing Nothing Nothing Nothing
   mappend = (<>)
 
 instance Semigroup ExecutableSection where
@@ -242,6 +243,7 @@ instance Semigroup ExecutableSection where
       executableSectionMain = executableSectionMain b <|> executableSectionMain a
     , executableSectionOtherModules = executableSectionOtherModules a <> executableSectionOtherModules b
     , executableSectionGeneratedOtherModules = executableSectionGeneratedOtherModules a <> executableSectionGeneratedOtherModules b
+    , executableSectionRtsOptions = executableSectionRtsOptions a <> executableSectionRtsOptions b
     }
 
 data VerbatimValue =
@@ -1366,13 +1368,13 @@ fromLibrarySectionPlain LibrarySection{..} = Library {
   }
 
 getMentionedExecutableModules :: ExecutableSection -> [Module]
-getMentionedExecutableModules (ExecutableSection main otherModules generatedModules)=
+getMentionedExecutableModules (ExecutableSection main otherModules generatedModules _rtsOptions)=
   maybe id (:) (toModule . Path.fromFilePath <$> main) $ fromMaybeList (otherModules <> generatedModules)
 
 toExecutable :: FilePath -> String -> Section ExecutableSection -> IO (Section Executable)
 toExecutable dir packageName_ =
     inferModules dir packageName_ getMentionedExecutableModules getExecutableModules fromExecutableSection (fromExecutableSection [])
-  . expandMain
+  . expandRtsOptions . expandMain
   where
     fromExecutableSection :: [Module] -> [Module] -> ExecutableSection -> Executable
     fromExecutableSection pathsModule inferableModules ExecutableSection{..} =
@@ -1381,12 +1383,33 @@ toExecutable dir packageName_ =
         otherModules = maybe (inferableModules ++ pathsModule) fromList executableSectionOtherModules
         generatedModules = maybe [] fromList executableSectionGeneratedOtherModules
 
+expandRtsOptions :: Section ExecutableSection -> Section ExecutableSection
+expandRtsOptions = flatten [] . expand
+  where
+    expand :: Section ExecutableSection -> Section ([String], ExecutableSection)
+    expand = fmap go
+      where
+        go :: ExecutableSection -> ([String], ExecutableSection)
+        go exec@ExecutableSection{..} = (fromMaybeList executableSectionRtsOptions, exec)
+
+    flatten :: [String] -> Section ([String], ExecutableSection) -> Section ExecutableSection
+    flatten outerRtsopts sect@Section{sectionData = (innerRtsopts, exec), ..} = sect{
+        sectionData = exec
+      , sectionGhcOptions = sectionGhcOptions ++ case innerRtsopts of
+        [] -> []
+        _ -> [show $ unwords ("-with-rtsopts" : rtsopts)]
+      , sectionConditionals = map (fmap $ flatten rtsopts) sectionConditionals
+      }
+      where
+        rtsopts = outerRtsopts ++ innerRtsopts
+
 expandMain :: Section ExecutableSection -> Section ExecutableSection
 expandMain = flatten . expand
   where
     expand :: Section ExecutableSection -> Section ([GhcOption], ExecutableSection)
     expand = fmap go
       where
+        go :: ExecutableSection -> ([GhcOption], ExecutableSection)
         go exec@ExecutableSection{..} =
           let
             (mainSrcFile, ghcOptions) = maybe (Nothing, []) (first Just . parseMain) executableSectionMain

--- a/test/EndToEndSpec.hs
+++ b/test/EndToEndSpec.hs
@@ -1436,6 +1436,33 @@ spec = around_ (inTempDirectoryNamed "foo") $ do
             ghc-options: -main-is Foo
           |]
 
+      describe "rts-options" $ do
+        it "maps rts-options to ghc-options" $ do
+          [i|
+          executable:
+            main: Main.hs
+            rts-options: -s -N
+          |] `shouldRenderTo` executable_ "foo" [i|
+            main-is: Main.hs
+            ghc-options: "-with-rtsopts -s -N"
+          |]
+
+        context "inside a conditional" $ do
+          it "includes rts-options from outer scope" $ do
+            [i|
+            executable:
+              main: Main.hs
+              rts-options: -s
+              when:
+                condition: flag(use-threading)
+                rts-options: -N
+            |] `shouldRenderTo` executable_ "foo" [i|
+              main-is: Main.hs
+              ghc-options: "-with-rtsopts -s"
+              if flag(use-threading)
+                ghc-options: "-with-rtsopts -s -N"
+            |]
+
     describe "when" $ do
       it "accepts conditionals" $ do
         [i|


### PR DESCRIPTION
This PR addresses https://github.com/sol/hpack/issues/237 by adding explicit support for `rts-options`.

**A note on semantics:** When `-with-rtsopts` are specified multiple times then `ghc` only takes the last occurrence into account.  For that reason, when a user wants to add additional rts options within a conditional s/he currently has to reiterate any outer rts options within the conditional, e.g.:

```yaml
executable:
  ghc-options: '"--with-rtsopts -s"'
  when:
    condition: flag(with-threading)
    ghc-options: '"--with-rtsopts -s -N"'
```

I implemented `rts-options` so that they are combined in the same way as most other things we support.  The following gives the same result as above:

```yaml
executable:
  rts-options: -s
  when:
    condition: flag(with-threading)
    rts-options: -N
```

The tests show how this is mapped to `.cabal`.

@snoyberg @quasicomputational @tfausak any thoughts?