### PR TITLE
Update links referring to master branch in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ at the Singapore Haskell meetup: http://typeful.net/talks/hpack
 
 ## Examples
 
- * Given this [package.yaml](https://github.com/sol/hpack/blob/master/package.yaml) running `hpack` will generate [hpack.cabal](https://github.com/sol/hpack/blob/master/hpack.cabal)
- * Given this [package.yaml](https://github.com/zalora/getopt-generics/blob/master/package.yaml) running `hpack` will generate [getopt-generics.cabal](https://github.com/zalora/getopt-generics/blob/master/getopt-generics.cabal)
- * Given this [package.yaml](https://github.com/hspec/sensei/blob/master/package.yaml) running `hpack` will generate [sensei.cabal](https://github.com/hspec/sensei/blob/master/sensei.cabal)
- * Given this [package.yaml](https://github.com/haskell-compat/base-orphans/blob/master/package.yaml) running `hpack` will generate [base-orphans.cabal](https://github.com/haskell-compat/base-orphans/blob/master/base-orphans.cabal)
+ * Given this [package.yaml](https://github.com/sol/hpack/blob/main/package.yaml) running `hpack` will generate [hpack.cabal](https://github.com/sol/hpack/blob/main/hpack.cabal)
+ * Given this [package.yaml](https://github.com/zalora/getopt-generics/blob/main/package.yaml) running `hpack` will generate [getopt-generics.cabal](https://github.com/zalora/getopt-generics/blob/main/getopt-generics.cabal)
+ * Given this [package.yaml](https://github.com/hspec/sensei/blob/main/package.yaml) running `hpack` will generate [sensei.cabal](https://github.com/hspec/sensei/blob/main/sensei.cabal)
+ * Given this [package.yaml](https://github.com/haskell-compat/base-orphans/blob/main/package.yaml) running `hpack` will generate [base-orphans.cabal](https://github.com/haskell-compat/base-orphans/blob/main/base-orphans.cabal)
 
 ## Documentation
 
@@ -662,7 +662,7 @@ steps are required.
 You can get binaries for use on Travis CI with:
 
 ```
-curl -sSL https://github.com/sol/hpack/raw/master/get-hpack.sh | bash
+curl -sSL https://github.com/sol/hpack/raw/main/get-hpack.sh | bash
 ```
 
 (both Linux and OS X are supported)


### PR DESCRIPTION
While attempting to install `hpack` from the link referred to in the README:

```
$ curl -sSL https://github.com/sol/hpack/raw/master/get-hpack.sh | bash
bash: line 6: syntax error near unexpected token `newline'
bash: line 6: `<!DOCTYPE html>'
curl: (23) Failed writing body (103 != 1370)
```

So, I figured I'd just do a quick string replace and submit a PR. It's just a quick edit and I haven't done any of the usual prerequisite legwork like checking to see if this duplicates work in an existing PR or anything, so feel free to completely disregard this PR and close it if it's not helpful ;)