### PR TITLE
Removed dead constructor PreferHash

### DIFF
--- a/src/Hpack.hs
+++ b/src/Hpack.hs
@@ -81,7 +81,10 @@ data Options = Options {
 , optionsToStdout :: Bool
 }
 
-data GenerateHashStrategy = ForceHash | ForceNoHash | PreferHash | PreferNoHash
+data GenerateHashStrategy
+  = ForceHash     -- ^ Option @--hash@ given.
+  | ForceNoHash   -- ^ Option @--no-hash given.
+  | PreferNoHash  -- ^ None of these option given, default behavior.
   deriving (Eq, Show)
 
 getOptions :: FilePath -> [String] -> IO (Maybe (Verbose, Options))
@@ -232,10 +235,9 @@ shouldGenerateHash :: Maybe CabalFile -> GenerateHashStrategy -> Bool
 shouldGenerateHash mExistingCabalFile strategy = case (strategy, mExistingCabalFile) of
   (ForceHash, _) -> True
   (ForceNoHash, _) -> False
-  (PreferHash, Nothing) -> True
   (PreferNoHash, Nothing) -> False
-  (_, Just CabalFile {cabalFileHash = Nothing}) -> False
-  (_, Just CabalFile {cabalFileHash = Just _}) -> True
+  (PreferNoHash, Just CabalFile {cabalFileHash = Nothing}) -> False
+  (PreferNoHash, Just CabalFile {cabalFileHash = Just _}) -> True
 
 renderCabalFile :: FilePath -> CabalFile -> [String]
 renderCabalFile file (CabalFile cabalVersion hpackVersion hash body) = cabalVersion ++ header file hpackVersion hash ++ body

--- a/test/HpackSpec.hs
+++ b/test/HpackSpec.hs
@@ -99,32 +99,27 @@ spec = do
 
     context "without an existing cabal file" $ do
       with ForceHash generatesHash
-      with PreferHash generatesHash
       with ForceNoHash doesNotGenerateHash
       with PreferNoHash doesNotGenerateHash
 
     context "with an existing cabal file" $ do
       context "without a hash" $ before_ (hpackWithStrategy ForceNoHash >> modifyPackageConfig) $ do
         with ForceHash generatesHash
-        with PreferHash doesNotGenerateHash
         with ForceNoHash doesNotGenerateHash
         with PreferNoHash doesNotGenerateHash
 
       context "with a hash" $ before_ (hpackWithStrategy ForceHash >> modifyPackageConfig) $ do
         with ForceHash generatesHash
-        with PreferHash generatesHash
         with ForceNoHash doesNotGenerateHash
         with PreferNoHash generatesHash
 
         context "with manual modifications" $ before_ modifyCabalFile $ do
           with ForceHash doesNotOverwrite
-          with PreferHash doesNotOverwrite
           with ForceNoHash doesNotGenerateHash
           with PreferNoHash doesNotOverwrite
 
       context "when created manually" $ before_ manuallyCreateCabalFile $ do
         with ForceHash doesNotOverwrite
-        with PreferHash doesNotOverwrite
         with ForceNoHash doesNotOverwrite
         with PreferNoHash doesNotOverwrite
 


### PR DESCRIPTION
The constructor PreferHash of GenerateHashStrategy is never used,
removing it clarifies the logic to the reader of the code.