### PR TITLE
CI: removed cron job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,6 @@ on:
   pull_request:
     branches:
       - main
-  schedule:
-    - cron: 0 0 * * *
 
 jobs:
   build:


### PR DESCRIPTION
This job has been failing for a month without triggering any
maintainance activity.

Save cycles, save CO2!