### PR TITLE
Fix #481 Allow `default-language` in `package.yaml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ values are merged with per section values.
 | `buildable` | · | | Per section takes precedence over top-level |
 | `source-dirs` | `hs-source-dirs` | | |
 | `default-extensions` | · | | |
+| `default-language` | . | `Haskell2010` | Also accepts `Haskell98` or `GHC2021`. Per section values prevail over top-level value |
 | `other-extensions` | · | | |
 | `ghc-options` | · | | |
 | `ghc-prof-options` | · | | |
@@ -296,7 +297,6 @@ This is done to allow compatibility with a wider range of `Cabal` versions.
 | `generated-other-modules` | | | Added to `other-modules` and `autogen-modules`. Since `0.23.0`.
 | `reexported-modules` | · | | |
 | `signatures` | · | | |
-| | `default-language` | `Haskell2010` | |
 
 #### Executable fields
 
@@ -305,7 +305,6 @@ This is done to allow compatibility with a wider range of `Cabal` versions.
 | `main` | `main-is` | | |
 | `other-modules` | · | All modules in `source-dirs` less `main` less any modules mentioned in `when` | |
 | `generated-other-modules` | | | Added to `other-modules` and `autogen-modules`. Since `0.23.0`.
-| | `default-language` | `Haskell2010` | |
 
 #### Test fields
 
@@ -315,7 +314,6 @@ This is done to allow compatibility with a wider range of `Cabal` versions.
 | `main` | `main-is` | | |
 | `other-modules` | · | All modules in `source-dirs` less `main` less any modules mentioned in `when` | |
 | `generated-other-modules` | | | Added to `other-modules` and `autogen-modules`. Since `0.23.0`.
-| | `default-language` | `Haskell2010` | |
 
 #### Benchmark fields
 
@@ -325,7 +323,6 @@ This is done to allow compatibility with a wider range of `Cabal` versions.
 | `main` | `main-is` | | |
 | `other-modules` | · | All modules in `source-dirs` less `main` less any modules mentioned in `when` | |
 | `generated-other-modules` | | | Added to `other-modules` and `autogen-modules`. Since `0.23.0`.
-| | `default-language` | `Haskell2010` | |
 
 #### Flags
 

--- a/src/Data/Aeson/Config/FromValue.hs
+++ b/src/Data/Aeson/Config/FromValue.hs
@@ -42,6 +42,7 @@ module Data.Aeson.Config.FromValue (
 
 import           Imports
 
+import           Data.Monoid (Last(..))
 import           GHC.Generics
 
 import           Data.Map.Lazy (Map)
@@ -142,6 +143,9 @@ instance (Selector sel, FromValue a) => GenericDecode (S1 sel (Rec0 a)) where
 
 instance {-# OVERLAPPING #-} (Selector sel, FromValue a) => GenericDecode (S1 sel (Rec0 (Maybe a))) where
   genericDecode = accessFieldWith (.:?)
+
+instance {-# OVERLAPPING #-} (Selector sel, FromValue a) => GenericDecode (S1 sel (Rec0 (Last a))) where
+  genericDecode = accessFieldWith (\ value key -> Last <$> (value .:? key))
 
 accessFieldWith :: forall sel a p. Selector sel => (Object -> Key -> Parser a) -> Options -> Value -> Parser (S1 sel (Rec0 a) p)
 accessFieldWith op Options{..} v = M1 . K1 <$> withObject (`op` Key.fromString label) v

--- a/test/Hpack/ConfigSpec.hs
+++ b/test/Hpack/ConfigSpec.hs
@@ -323,9 +323,9 @@ spec = do
             cpp-options: -DTEST
         |]
         (`shouldBe` package {
-          packageLibrary = Just (section library) {sectionCppOptions = ["-DFOO", "-DLIB"]}
-        , packageExecutables = Map.fromList [("foo", (section $ executable "Main.hs") {sectionCppOptions = ["-DFOO", "-DFOO"]})]
-        , packageTests = Map.fromList [("spec", (section $ executable "Spec.hs") {sectionCppOptions = ["-DFOO", "-DTEST"]})]
+          packageLibrary = Just (sectionWithHaskell2010 library) {sectionCppOptions = ["-DFOO", "-DLIB"]}
+        , packageExecutables = Map.fromList [("foo", (sectionWithHaskell2010 $ executable "Main.hs") {sectionCppOptions = ["-DFOO", "-DFOO"]})]
+        , packageTests = Map.fromList [("spec", (sectionWithHaskell2010 $ executable "Spec.hs") {sectionCppOptions = ["-DFOO", "-DTEST"]})]
         }
         )
 
@@ -347,9 +347,9 @@ spec = do
             cc-options: -O0
         |]
         (`shouldBe` package {
-          packageLibrary = Just (section library) {sectionCcOptions = ["-Wall", "-fLIB"]}
-        , packageExecutables = Map.fromList [("foo", (section $ executable "Main.hs") {sectionCcOptions = ["-Wall", "-O2"]})]
-        , packageTests = Map.fromList [("spec", (section $ executable "Spec.hs") {sectionCcOptions = ["-Wall", "-O0"]})]
+          packageLibrary = Just (sectionWithHaskell2010 library) {sectionCcOptions = ["-Wall", "-fLIB"]}
+        , packageExecutables = Map.fromList [("foo", (sectionWithHaskell2010 $ executable "Main.hs") {sectionCcOptions = ["-Wall", "-O2"]})]
+        , packageTests = Map.fromList [("spec", (sectionWithHaskell2010 $ executable "Spec.hs") {sectionCcOptions = ["-Wall", "-O0"]})]
         }
         )
 
@@ -371,9 +371,9 @@ spec = do
             ghcjs-options: -ghcjs3
         |]
         (`shouldBe` package {
-          packageLibrary = Just (section library) {sectionGhcjsOptions = ["-dedupe", "-ghcjs1"]}
-        , packageExecutables = Map.fromList [("foo", (section $ executable "Main.hs") {sectionGhcjsOptions = ["-dedupe", "-ghcjs2"]})]
-        , packageTests = Map.fromList [("spec", (section $ executable "Spec.hs") {sectionGhcjsOptions = ["-dedupe", "-ghcjs3"]})]
+          packageLibrary = Just (sectionWithHaskell2010 library) {sectionGhcjsOptions = ["-dedupe", "-ghcjs1"]}
+        , packageExecutables = Map.fromList [("foo", (sectionWithHaskell2010 $ executable "Main.hs") {sectionGhcjsOptions = ["-dedupe", "-ghcjs2"]})]
+        , packageTests = Map.fromList [("spec", (sectionWithHaskell2010 $ executable "Spec.hs") {sectionGhcjsOptions = ["-dedupe", "-ghcjs3"]})]
         }
         )
 
@@ -383,7 +383,7 @@ spec = do
           ld-options: -static
         |]
         (`shouldBe` package {
-          packageLibrary = Just (section library) {sectionLdOptions = ["-static"]}
+          packageLibrary = Just (sectionWithHaskell2010 library) {sectionLdOptions = ["-static"]}
         }
         )
 
@@ -398,8 +398,8 @@ spec = do
             main: Main.hs
         |]
         (`shouldBe` package {
-          packageLibrary = Just (section library) {sectionBuildable = Just True}
-        , packageExecutables = Map.fromList [("foo", (section $ executable "Main.hs") {sectionBuildable = Just False})]
+          packageLibrary = Just (sectionWithHaskell2010 library) {sectionBuildable = Just True}
+        , packageExecutables = Map.fromList [("foo", (sectionWithHaskell2010 $ executable "Main.hs") {sectionBuildable = Just False})]
         }
         )
 
@@ -421,7 +421,7 @@ spec = do
               - foo
               - bar
           |]
-          (packageLibrary >>> (`shouldBe` Just (section library) {sectionSourceDirs = ["foo", "bar"]}))
+          (packageLibrary >>> (`shouldBe` Just (sectionWithHaskell2010 library) {sectionSourceDirs = ["foo", "bar"]}))
 
       it "accepts default-extensions" $ do
         withPackageConfig_ [i|
@@ -430,7 +430,7 @@ spec = do
               - Foo
               - Bar
           |]
-          (packageLibrary >>> (`shouldBe` Just (section library) {sectionDefaultExtensions = ["Foo", "Bar"]}))
+          (packageLibrary >>> (`shouldBe` Just (sectionWithHaskell2010 library) {sectionDefaultExtensions = ["Foo", "Bar"]}))
 
       it "accepts global default-extensions" $ do
         withPackageConfig_ [i|
@@ -439,7 +439,7 @@ spec = do
             - Bar
           library: {}
           |]
-          (packageLibrary >>> (`shouldBe` Just (section library) {sectionDefaultExtensions = ["Foo", "Bar"]}))
+          (packageLibrary >>> (`shouldBe` Just (sectionWithHaskell2010 library) {sectionDefaultExtensions = ["Foo", "Bar"]}))
 
       it "accepts global source-dirs" $ do
         withPackageConfig_ [i|
@@ -448,14 +448,14 @@ spec = do
             - bar
           library: {}
           |]
-          (packageLibrary >>> (`shouldBe` Just (section library) {sectionSourceDirs = ["foo", "bar"]}))
+          (packageLibrary >>> (`shouldBe` Just (sectionWithHaskell2010 library) {sectionSourceDirs = ["foo", "bar"]}))
 
       it "allows to specify exposed" $ do
         withPackageConfig_ [i|
           library:
             exposed: no
           |]
-          (packageLibrary >>> (`shouldBe` Just (section library{libraryExposed = Just False})))
+          (packageLibrary >>> (`shouldBe` Just (sectionWithHaskell2010 library{libraryExposed = Just False})))
 
     context "when reading executable section" $ do
       it "reads executables section" $ do
@@ -464,14 +464,14 @@ spec = do
             foo:
               main: driver/Main.hs
           |]
-          (packageExecutables >>> (`shouldBe` Map.fromList [("foo", section $ executable "driver/Main.hs")]))
+          (packageExecutables >>> (`shouldBe` Map.fromList [("foo", (sectionWithHaskell2010 $ executable "driver/Main.hs"))]))
 
       it "reads executable section" $ do
         withPackageConfig_ [i|
           executable:
             main: driver/Main.hs
           |]
-          (packageExecutables >>> (`shouldBe` Map.fromList [("foo", section $ executable "driver/Main.hs")]))
+          (packageExecutables >>> (`shouldBe` Map.fromList [("foo", (sectionWithHaskell2010 $ executable "driver/Main.hs"))]))
 
       context "with both executable and executables" $ do
         it "gives executable precedence" $ do
@@ -482,7 +482,7 @@ spec = do
               foo2:
                 main: driver/Main2.hs
             |]
-            (packageExecutables >>> (`shouldBe` Map.fromList [("foo", section $ executable "driver/Main1.hs")]))
+            (packageExecutables >>> (`shouldBe` Map.fromList [("foo", (sectionWithHaskell2010 $ executable "driver/Main1.hs"))]))
 
         it "warns" $ do
           withPackageWarnings_ [i|
@@ -504,7 +504,7 @@ spec = do
                 - foo
                 - bar
           |]
-          (packageExecutables >>> (`shouldBe` Map.fromList [("foo", (section (executable "Main.hs") {executableOtherModules = ["Paths_foo"]}) {sectionSourceDirs = ["foo", "bar"]})]))
+          (packageExecutables >>> (`shouldBe` Map.fromList [("foo", (sectionWithHaskell2010 (executable "Main.hs") {executableOtherModules = ["Paths_foo"]}) {sectionSourceDirs = ["foo", "bar"]})]))
 
       it "accepts global source-dirs" $ do
         withPackageConfig_ [i|
@@ -515,7 +515,7 @@ spec = do
             foo:
               main: Main.hs
           |]
-          (packageExecutables >>> (`shouldBe` Map.fromList [("foo", (section (executable "Main.hs") {executableOtherModules = ["Paths_foo"]}) {sectionSourceDirs = ["foo", "bar"]})]))
+          (packageExecutables >>> (`shouldBe` Map.fromList [("foo", (sectionWithHaskell2010 (executable "Main.hs") {executableOtherModules = ["Paths_foo"]}) {sectionSourceDirs = ["foo", "bar"]})]))
 
       it "accepts default-extensions" $ do
         withPackageConfig_ [i|
@@ -526,7 +526,7 @@ spec = do
                 - Foo
                 - Bar
           |]
-          (packageExecutables >>> (`shouldBe` Map.fromList [("foo", (section $ executable "driver/Main.hs") {sectionDefaultExtensions = ["Foo", "Bar"]})]))
+          (packageExecutables >>> (`shouldBe` Map.fromList [("foo", (sectionWithHaskell2010 $ executable "driver/Main.hs") {sectionDefaultExtensions = ["Foo", "Bar"]})]))
 
       it "accepts global default-extensions" $ do
         withPackageConfig_ [i|
@@ -537,7 +537,7 @@ spec = do
             foo:
               main: driver/Main.hs
           |]
-          (packageExecutables >>> (`shouldBe` Map.fromList [("foo", (section $ executable "driver/Main.hs") {sectionDefaultExtensions = ["Foo", "Bar"]})]))
+          (packageExecutables >>> (`shouldBe` Map.fromList [("foo", (sectionWithHaskell2010 $ executable "driver/Main.hs") {sectionDefaultExtensions = ["Foo", "Bar"]})]))
 
       it "accepts GHC options" $ do
         withPackageConfig_ [i|
@@ -546,7 +546,7 @@ spec = do
               main: driver/Main.hs
               ghc-options: -Wall
           |]
-          (`shouldBe` package {packageExecutables = Map.fromList [("foo", (section $ executable "driver/Main.hs") {sectionGhcOptions = ["-Wall"]})]})
+          (`shouldBe` package {packageExecutables = Map.fromList [("foo", (sectionWithHaskell2010 $ executable "driver/Main.hs") {sectionGhcOptions = ["-Wall"]})]})
 
       it "accepts global GHC options" $ do
         withPackageConfig_ [i|
@@ -555,7 +555,7 @@ spec = do
             foo:
               main: driver/Main.hs
           |]
-          (`shouldBe` package {packageExecutables = Map.fromList [("foo", (section $ executable "driver/Main.hs") {sectionGhcOptions = ["-Wall"]})]})
+          (`shouldBe` package {packageExecutables = Map.fromList [("foo", (sectionWithHaskell2010 $ executable "driver/Main.hs") {sectionGhcOptions = ["-Wall"]})]})
 
       it "accepts GHC profiling options" $ do
         withPackageConfig_ [i|
@@ -564,7 +564,7 @@ spec = do
               main: driver/Main.hs
               ghc-prof-options: -fprof-auto
           |]
-          (`shouldBe` package {packageExecutables = Map.fromList [("foo", (section $ executable "driver/Main.hs") {sectionGhcProfOptions = ["-fprof-auto"]})]})
+          (`shouldBe` package {packageExecutables = Map.fromList [("foo", (sectionWithHaskell2010 $ executable "driver/Main.hs") {sectionGhcProfOptions = ["-fprof-auto"]})]})
 
       it "accepts global GHC profiling options" $ do
         withPackageConfig_ [i|
@@ -573,7 +573,7 @@ spec = do
             foo:
               main: driver/Main.hs
           |]
-          (`shouldBe` package {packageExecutables = Map.fromList [("foo", (section $ executable "driver/Main.hs") {sectionGhcProfOptions = ["-fprof-auto"]})]})
+          (`shouldBe` package {packageExecutables = Map.fromList [("foo", (sectionWithHaskell2010 $ executable "driver/Main.hs") {sectionGhcProfOptions = ["-fprof-auto"]})]})
 
     context "when reading test section" $ do
       it "reads test section" $ do
@@ -582,7 +582,7 @@ spec = do
             spec:
               main: test/Spec.hs
           |]
-          (`shouldBe` package {packageTests = Map.fromList [("spec", section $ executable "test/Spec.hs")]})
+          (`shouldBe` package {packageTests = Map.fromList [("spec", (sectionWithHaskell2010 $ executable "test/Spec.hs"))]})
 
     context "when a specified source directory does not exist" $ do
       it "warns" $ do

--- a/test/Hpack/RenderSpec.hs
+++ b/test/Hpack/RenderSpec.hs
@@ -16,6 +16,10 @@ library = Library Nothing Nothing [] [] [] [] []
 executable :: Section Executable
 executable = section (Executable (Just "Main.hs") [] [])
 
+executableWithHaskell2010 :: Section Executable
+executableWithHaskell2010 =
+  executable {sectionDefaultLanguage = Just $ Language "Haskell2010"}
+
 renderEmptySection :: Empty -> [Element]
 renderEmptySection Empty = []
 
@@ -110,7 +114,7 @@ spec = do
         ]
 
     it "includes buildable" $ do
-      renderPackage_ package {packageLibrary = Just (section library){sectionBuildable = Just False}} `shouldBe` unlines [
+      renderPackage_ package {packageLibrary = Just (sectionWithHaskell2010 library){sectionBuildable = Just False}} `shouldBe` unlines [
           "name: foo"
         , "version: 0.0.0"
         , "build-type: Simple"
@@ -122,7 +126,7 @@ spec = do
 
     context "when rendering library section" $ do
       it "renders library section" $ do
-        renderPackage_ package {packageLibrary = Just $ section library} `shouldBe` unlines [
+        renderPackage_ package {packageLibrary = Just (sectionWithHaskell2010 library)} `shouldBe` unlines [
             "name: foo"
           , "version: 0.0.0"
           , "build-type: Simple"
@@ -147,7 +151,7 @@ spec = do
           ]
 
       it "retains section field order" $ do
-        renderPackageWith defaultRenderSettings 0 [] [("executable foo", ["default-language", "main-is", "ghc-options"])] package {packageExecutables = [("foo", executable {sectionGhcOptions = ["-Wall", "-Werror"]})]} `shouldBe` unlines [
+        renderPackageWith defaultRenderSettings 0 [] [("executable foo", ["default-language", "main-is", "ghc-options"])] package {packageExecutables = [("foo", executableWithHaskell2010 {sectionGhcOptions = ["-Wall", "-Werror"]})]} `shouldBe` unlines [
             "name: foo"
           , "version: 0.0.0"
           , "build-type: Simple"
@@ -164,7 +168,7 @@ spec = do
               [ ("foo", defaultInfo { dependencyInfoVersion = versionRange "== 0.1.0" })
               , ("bar", defaultInfo)
               ]
-        renderPackage_ package {packageExecutables = [("foo", executable {sectionDependencies = dependencies})]} `shouldBe` unlines [
+        renderPackage_ package {packageExecutables = [("foo", executableWithHaskell2010 {sectionDependencies = dependencies})]} `shouldBe` unlines [
             "name: foo"
           , "version: 0.0.0"
           , "build-type: Simple"
@@ -178,7 +182,7 @@ spec = do
           ]
 
       it "includes GHC options" $ do
-        renderPackage_ package {packageExecutables = [("foo", executable {sectionGhcOptions = ["-Wall", "-Werror"]})]} `shouldBe` unlines [
+        renderPackage_ package {packageExecutables = [("foo", executableWithHaskell2010 {sectionGhcOptions = ["-Wall", "-Werror"]})]} `shouldBe` unlines [
             "name: foo"
           , "version: 0.0.0"
           , "build-type: Simple"
@@ -190,7 +194,7 @@ spec = do
           ]
 
       it "includes frameworks" $ do
-        renderPackage_ package {packageExecutables = [("foo", executable {sectionFrameworks = ["foo", "bar"]})]} `shouldBe` unlines [
+        renderPackage_ package {packageExecutables = [("foo", executableWithHaskell2010 {sectionFrameworks = ["foo", "bar"]})]} `shouldBe` unlines [
             "name: foo"
           , "version: 0.0.0"
           , "build-type: Simple"
@@ -204,7 +208,7 @@ spec = do
           ]
 
       it "includes extra-framework-dirs" $ do
-        renderPackage_ package {packageExecutables = [("foo", executable {sectionExtraFrameworksDirs = ["foo", "bar"]})]} `shouldBe` unlines [
+        renderPackage_ package {packageExecutables = [("foo", executableWithHaskell2010 {sectionExtraFrameworksDirs = ["foo", "bar"]})]} `shouldBe` unlines [
             "name: foo"
           , "version: 0.0.0"
           , "build-type: Simple"
@@ -218,7 +222,7 @@ spec = do
           ]
 
       it "includes GHC profiling options" $ do
-        renderPackage_ package {packageExecutables = [("foo", executable {sectionGhcProfOptions = ["-fprof-auto", "-rtsopts"]})]} `shouldBe` unlines [
+        renderPackage_ package {packageExecutables = [("foo", executableWithHaskell2010 {sectionGhcProfOptions = ["-fprof-auto", "-rtsopts"]})]} `shouldBe` unlines [
             "name: foo"
           , "version: 0.0.0"
           , "build-type: Simple"


### PR DESCRIPTION
The default remains as `Haskell2010` but this also allows `GHC2021`.

The documentation is also updated, accordingly.

Tested by compiling and using with GHC 9.2.1 on Windows.