### PR TITLE
Add the simplest mixin example. Fixes #453.

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,10 @@ see and how its signatures are filled in:
 
 ```
   dependencies:
+    # This is the simplest mixin syntax with no module renaming or hiding.
+    - name: base
+      mixin:
+        - ''
     # This gives you a shorter name to import from, and hides the other modules.
     - name: containers
       mixin:


### PR DESCRIPTION
This adds the "simplest syntax example" from the [cabal docs](https://cabal.readthedocs.io/en/latest/cabal-package.html#pkg-field-mixins) replacing foo with base in the example.