### PR TITLE
Accept `.cabal` aliases for fields where `hpack` and `.cabal` differ

### DIFF
--- a/test/Hpack/ConfigSpec.hs
+++ b/test/Hpack/ConfigSpec.hs
@@ -425,6 +425,15 @@ spec = do
           |]
           (packageLibrary >>> (`shouldBe` Just (section library) {sectionSourceDirs = ["foo", "bar"]}))
 
+      it "accepts hs-source-dirs as an alias for source-dirs" $ do
+        withPackageConfig_ [i|
+          library:
+            hs-source-dirs:
+              - foo
+              - bar
+          |]
+          (packageLibrary >>> (`shouldBe` Just (section library) {sectionSourceDirs = ["foo", "bar"]}))
+
       it "accepts default-extensions" $ do
         withPackageConfig_ [i|
           library:


### PR DESCRIPTION
- `hs-source-dirs` as an alias for `source-dirs`
- `build-depends` as an alias for `dependencies`
- `pkgconfig-depends` as an alias for `pkg-config-dependencies`
- `build-tool-depends` as an alias for `build-tools`