### PR TITLE
Warn on deprecated aliases field

### DIFF
--- a/test/Hpack/Syntax/DependenciesSpec.hs
+++ b/test/Hpack/Syntax/DependenciesSpec.hs
@@ -212,7 +212,7 @@ spec = do
               outer-name:
                 name: inner-name
                 path: somewhere
-            |] `shouldDecodeTo` Right (Dependencies [("outer-name", defaultInfo { dependencyInfoVersion = DependencyVersion source AnyVersion })], ["$.outer-name.name"])
+            |] `shouldDecodeTo` Right (Dependencies [("outer-name", defaultInfo { dependencyInfoVersion = DependencyVersion source AnyVersion })], ["$.outer-name.name"], [])
 
           it "defaults to any version" $ do
             [yaml|


### PR DESCRIPTION
Don't warn on `pkgconfig-depends` for now, as `pkg-config-dependencies` isn't that nice neither.