### PR TITLE
Remove broken link in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -714,10 +714,5 @@ steps are required.
 
 ## Binaries for use on Travis CI
 
-You can get binaries for use on Travis CI with:
-
-```
-curl -sSL https://github.com/sol/hpack/raw/master/get-hpack.sh | bash
-```
-
-(both Linux and OS X are supported)
+Previously, we distributed binaries for use on Travis CI but, currently, we do
+not do so.


### PR DESCRIPTION
It seems like the trunk branch got renamed.

- [ ] Did you add a new feature to `hpack`?
  - [ ] Did you add an acceptance test for that new feature to `test/EndToEndSpec.hs`?
