### PR TITLE
Add examples for flags in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,20 @@ This is done to allow compatibility with a wider range of `Cabal` versions.
 | `manual` | · | | Required (unlike Cabal) |
 | `default` | · | | Required (unlike Cabal) |
 
+Flags must be specified as an object:
+
+```
+flags:
+  development:
+    description: A development or production build 
+    manual: True
+    default: False
+  fast:
+    manual: True
+    default: False
+
+```
+
 #### Dependencies
 
 Dependencies can be specified as either a list or an object. These are


### PR DESCRIPTION
I couldn't find any documentation of flags and I ended up looking at the code. It wasn't clear to me from the current docs:

1. what was the top-level object name
2. wether individual flags had to be specified as objects or a list

- [x] Did you add a new feature to `hpack`? No
- [x] Did you add an acceptance test for that new feature to `test/EndToEndSpec.hs`? Not applicable
