### PR TITLE
Update .github/workflows/build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,13 @@
 name: build
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: actions/cache@v2
         with:
-          key: ${{ runner.os }}-v2-${{ matrix.ghc }}-${{ github.sha }}
+          key: ${{ runner.os }}-v2-${{ matrix.ghc }}-${{ github.run_id }}
           path: ~/.cabal/store
           restore-keys: ${{ runner.os }}-v2-${{ matrix.ghc }}-
 


### PR DESCRIPTION
Use `github.run_id` instead of `github.sha` for the cache key, so that we don't get an exact cache hit for scheduled runs. This is desirable as the cache is not saved on exact cache hits.