### PR TITLE
Fix #530 Introduce `HpackError` type, for Hpack errors

### DIFF
--- a/hpack.cabal
+++ b/hpack.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.7.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -63,6 +63,7 @@ library
       Data.Aeson.Config.Util
       Hpack.CabalFile
       Hpack.Defaults
+      Hpack.Error
       Hpack.Haskell
       Hpack.License
       Hpack.Module
@@ -188,6 +189,7 @@ test-suite spec
       Hpack.CabalFile
       Hpack.Config
       Hpack.Defaults
+      Hpack.Error
       Hpack.Haskell
       Hpack.License
       Hpack.Module

--- a/src/Hpack/Config.hs
+++ b/src/Hpack/Config.hs
@@ -112,6 +112,7 @@ import           Data.Aeson.Config.Types
 import           Data.Aeson.Config.FromValue hiding (decodeValue)
 import qualified Data.Aeson.Config.FromValue as Config
 
+import           Hpack.Error (HpackError (..), ProgramName (..), hpackProgName)
 import           Hpack.Syntax.Defaults
 import           Hpack.Util hiding (expandGlobs)
 import qualified Hpack.Util as Util
@@ -631,29 +632,22 @@ type ParsePackageConfig = PackageConfigWithDefaults ParseCSources ParseCxxSource
 instance FromValue ParsePackageConfig
 
 type Warnings m = WriterT [String] m
-type Errors = ExceptT String
+type Errors = ExceptT HpackError
 
-decodeYaml :: FromValue a => ProgramName -> FilePath -> Warnings (Errors IO) a
-decodeYaml programName file = do
+decodeYaml :: FromValue a => FilePath -> Warnings (Errors IO) a
+decodeYaml file = do
   (warnings, a) <- lift (ExceptT $ Yaml.decodeYaml file)
   tell warnings
-  decodeValue programName file a
+  decodeValue file a
 
 data DecodeOptions = DecodeOptions {
-  decodeOptionsProgramName :: ProgramName
-, decodeOptionsTarget :: FilePath
+  decodeOptionsTarget :: FilePath
 , decodeOptionsUserDataDir :: Maybe FilePath
-, decodeOptionsDecode :: FilePath -> IO (Either String ([String], Value))
+, decodeOptionsDecode :: FilePath -> IO (Either HpackError ([String], Value))
 }
 
-newtype ProgramName = ProgramName String
-  deriving (Eq, Show)
-
-instance IsString ProgramName where
-  fromString = ProgramName
-
 defaultDecodeOptions :: DecodeOptions
-defaultDecodeOptions = DecodeOptions "hpack" packageConfig Nothing Yaml.decodeYaml
+defaultDecodeOptions = DecodeOptions packageConfig Nothing Yaml.decodeYaml
 
 data DecodeResult = DecodeResult {
   decodeResultPackage :: Package
@@ -662,14 +656,14 @@ data DecodeResult = DecodeResult {
 , decodeResultWarnings :: [String]
 } deriving (Eq, Show)
 
-readPackageConfig :: DecodeOptions -> IO (Either String DecodeResult)
-readPackageConfig (DecodeOptions programName file mUserDataDir readValue) = runExceptT $ fmap addCabalFile . runWriterT $ do
+readPackageConfig :: DecodeOptions -> IO (Either HpackError DecodeResult)
+readPackageConfig (DecodeOptions file mUserDataDir readValue) = runExceptT $ fmap addCabalFile . runWriterT $ do
   (warnings, value) <- lift . ExceptT $ readValue file
   tell warnings
-  config <- decodeValue programName file value
+  config <- decodeValue file value
   dir <- liftIO $ takeDirectory <$> canonicalizePath file
-  userDataDir <- liftIO $ maybe (getAppUserDataDirectory "hpack") return mUserDataDir
-  toPackage programName userDataDir dir config
+  userDataDir <- liftIO $ maybe (getAppUserDataDirectory $ unProgramName hpackProgName) return mUserDataDir
+  toPackage userDataDir dir config
   where
     addCabalFile :: ((Package, String), [String]) -> DecodeResult
     addCabalFile ((pkg, cabalVersion), warnings) = DecodeResult pkg cabalVersion (takeDirectory_ file </> (packageName pkg ++ ".cabal")) warnings
@@ -890,12 +884,12 @@ determineCabalVersion inferredLicense pkg@Package{..} = (
 sectionAll :: (Semigroup b, Monoid b) => (Section a -> b) -> Section a -> b
 sectionAll f sect = f sect <> foldMap (foldMap $ sectionAll f) (sectionConditionals sect)
 
-decodeValue :: FromValue a => ProgramName -> FilePath -> Value -> Warnings (Errors IO) a
-decodeValue (ProgramName programName) file value = do
-  (r, unknown, deprecated) <- lift . ExceptT . return $ first (prefix ++) (Config.decodeValue value)
+decodeValue :: FromValue a => FilePath -> Value -> Warnings (Errors IO) a
+decodeValue file value = do
+  (r, unknown, deprecated) <- lift . ExceptT . return $ first (DecodeValueError file) (Config.decodeValue value)
   case r of
     UnsupportedSpecVersion v -> do
-      lift $ throwE ("The file " ++ file ++ " requires version " ++ showVersion v ++ " of the Hpack package specification, however this version of " ++ programName ++ " only supports versions up to " ++ showVersion Hpack.version ++ ". Upgrading to the latest version of " ++ programName ++ " may resolve this issue.")
+      lift $ throwE $ HpackVersionUnsupported file v Hpack.version
     SupportedSpecVersion a -> do
       tell (map formatUnknownField unknown)
       tell (map formatDeprecatedField deprecated)
@@ -1049,9 +1043,9 @@ type ConfigWithDefaults = Product
 type CommonOptionsWithDefaults a = Product DefaultsConfig (CommonOptions ParseCSources ParseCxxSources ParseJsSources a)
 type WithCommonOptionsWithDefaults a = Product DefaultsConfig (WithCommonOptions ParseCSources ParseCxxSources ParseJsSources a)
 
-toPackage :: ProgramName -> FilePath -> FilePath -> ConfigWithDefaults -> Warnings (Errors IO) (Package, String)
-toPackage programName userDataDir dir =
-      expandDefaultsInConfig programName userDataDir dir
+toPackage :: FilePath -> FilePath -> ConfigWithDefaults -> Warnings (Errors IO) (Package, String)
+toPackage userDataDir dir =
+      expandDefaultsInConfig userDataDir dir
   >=> setDefaultLanguage "Haskell2010"
   >>> traverseConfig (expandForeignSources dir)
   >=> toPackage_ dir
@@ -1061,35 +1055,32 @@ toPackage programName userDataDir dir =
         setLanguage = (mempty { commonOptionsLanguage = Alias . Last $ Just (Just language) } <>)
 
 expandDefaultsInConfig
-  :: ProgramName
-  -> FilePath
+  :: FilePath
   -> FilePath
   -> ConfigWithDefaults
   -> Warnings (Errors IO) (Config ParseCSources ParseCxxSources ParseJsSources)
-expandDefaultsInConfig programName userDataDir dir = bitraverse (expandGlobalDefaults programName userDataDir dir) (expandSectionDefaults programName userDataDir dir)
+expandDefaultsInConfig userDataDir dir = bitraverse (expandGlobalDefaults userDataDir dir) (expandSectionDefaults userDataDir dir)
 
 expandGlobalDefaults
-  :: ProgramName
-  -> FilePath
+  :: FilePath
   -> FilePath
   -> CommonOptionsWithDefaults Empty
   -> Warnings (Errors IO) (CommonOptions ParseCSources ParseCxxSources ParseJsSources Empty)
-expandGlobalDefaults programName userDataDir dir = do
-  fmap (`Product` Empty) >>> expandDefaults programName userDataDir dir >=> \ (Product c Empty) -> return c
+expandGlobalDefaults userDataDir dir = do
+  fmap (`Product` Empty) >>> expandDefaults userDataDir dir >=> \ (Product c Empty) -> return c
 
 expandSectionDefaults
-  :: ProgramName
-  -> FilePath
+  :: FilePath
   -> FilePath
   -> PackageConfigWithDefaults ParseCSources ParseCxxSources ParseJsSources
   -> Warnings (Errors IO) (PackageConfig ParseCSources ParseCxxSources ParseJsSources)
-expandSectionDefaults programName userDataDir dir p@PackageConfig{..} = do
-  library <- traverse (expandDefaults programName userDataDir dir) packageConfigLibrary
-  internalLibraries <- traverse (traverse (expandDefaults programName userDataDir dir)) packageConfigInternalLibraries
-  executable <- traverse (expandDefaults programName userDataDir dir) packageConfigExecutable
-  executables <- traverse (traverse (expandDefaults programName userDataDir dir)) packageConfigExecutables
-  tests <- traverse (traverse (expandDefaults programName userDataDir dir)) packageConfigTests
-  benchmarks <- traverse (traverse (expandDefaults programName userDataDir dir)) packageConfigBenchmarks
+expandSectionDefaults userDataDir dir p@PackageConfig{..} = do
+  library <- traverse (expandDefaults userDataDir dir) packageConfigLibrary
+  internalLibraries <- traverse (traverse (expandDefaults userDataDir dir)) packageConfigInternalLibraries
+  executable <- traverse (expandDefaults userDataDir dir) packageConfigExecutable
+  executables <- traverse (traverse (expandDefaults userDataDir dir)) packageConfigExecutables
+  tests <- traverse (traverse (expandDefaults userDataDir dir)) packageConfigTests
+  benchmarks <- traverse (traverse (expandDefaults userDataDir dir)) packageConfigBenchmarks
   return p{
       packageConfigLibrary = library
     , packageConfigInternalLibraries = internalLibraries
@@ -1101,12 +1092,11 @@ expandSectionDefaults programName userDataDir dir p@PackageConfig{..} = do
 
 expandDefaults
   :: (FromValue a, Semigroup a, Monoid a)
-  => ProgramName
-  -> FilePath
+  => FilePath
   -> FilePath
   -> WithCommonOptionsWithDefaults a
   -> Warnings (Errors IO) (WithCommonOptions ParseCSources ParseCxxSources ParseJsSources a)
-expandDefaults programName userDataDir = expand []
+expandDefaults userDataDir = expand []
   where
     expand :: (FromValue a, Semigroup a, Monoid a) =>
          [FilePath]
@@ -1126,14 +1116,14 @@ expandDefaults programName userDataDir = expand []
       file <- lift $ ExceptT (ensure userDataDir dir defaults)
       seen_ <- lift (checkCycle seen file)
       let dir_ = takeDirectory file
-      decodeYaml programName file >>= expand seen_ dir_
+      decodeYaml file >>= expand seen_ dir_
 
     checkCycle :: [FilePath] -> FilePath -> Errors IO [FilePath]
     checkCycle seen file = do
       canonic <- liftIO $ canonicalizePath file
       let seen_ = canonic : seen
       when (canonic `elem` seen) $ do
-        throwE ("cycle in defaults (" ++ intercalate " -> " (reverse seen_) ++ ")")
+        throwE $ CycleInDefaultsError $ reverse seen_
       return seen_
 
 toExecutableMap :: Monad m => String -> Maybe (Map String a) -> Maybe a -> Warnings m (Maybe (Map String a))

--- a/src/Hpack/Error.hs
+++ b/src/Hpack/Error.hs
@@ -1,0 +1,88 @@
+{-# LANGUAGE RecordWildCards #-}
+
+-- | Errors returned by Hpack library functions.
+module Hpack.Error
+  ( HpackError (..)
+  , hpackProgName
+  , renderHpackError
+  , ProgramName (..)
+    -- * Re-export of types used in Hpack errors
+  , Status (..)
+  , Version (..)
+  , URL
+  ) where
+
+import qualified Data.ByteString.Char8 as B
+import           Data.List (intercalate)
+import           Data.String (IsString (..))
+import           Data.Version (Version (..), showVersion)
+import           Network.HTTP.Types.Status (Status (..))
+
+-- | Type synonyn representing URLs.
+type URL = String
+
+-- | Type representing errors returned by functions exported by the modules of
+-- the Hpack library.
+data HpackError
+  = HpackVersionUnsupported !FilePath !Version !Version
+  | DefaultsFileNotFound !FilePath
+  | DefaultsFileUrlNotFound !URL
+  | DownloadingFileFailed !URL !Status
+  | CycleInDefaultsError ![FilePath]
+  | HpackParseAesonException !FilePath !String
+  | HpackParseYamlException !FilePath !String
+  | HpackParseYamlParseException {
+      yamlFile :: !FilePath
+    , yamlProblem :: !String
+    , yamlContext :: !String
+    , yamlIndex :: !Int
+      -- ^ Not displayed by 'renderHpackError'.
+    , yamlLine :: !Int
+    , yamlColumn :: !Int
+    }
+  | HpackParseOtherException !FilePath !String
+  | DecodeValueError !FilePath !String
+    -- | Data constructor for users of the Hpack library that do not use the
+    -- default 'Hpack.Yaml.decodeYaml' and wish to use 'String' as an
+    -- error/exception type.
+  | HpackOtherException !FilePath !String
+  deriving (Eq, Show)
+
+renderHpackError :: ProgramName -> HpackError -> String
+renderHpackError (ProgramName progName) (HpackVersionUnsupported file wanted supported) =
+  "The file " ++ file ++ " requires version " ++ showVersion wanted ++
+  " of the Hpack package specification, however this version of " ++
+  progName ++ " only supports versions up to " ++ showVersion supported ++
+  ". Upgrading to the latest version of " ++ progName ++ " may resolve this issue."
+renderHpackError _ (DefaultsFileNotFound file) =
+  "Invalid value for \"defaults\"! File " ++ file ++ " does not exist!"
+renderHpackError _ (DefaultsFileUrlNotFound url) =
+  "Invalid value for \"defaults\"! File " ++ url ++ " does not exist!"
+renderHpackError _ (DownloadingFileFailed url status) =
+  "Error while downloading " ++ url ++ " (" ++ formatStatus status ++ ")"
+ where
+  formatStatus :: Status -> String
+  formatStatus (Status code message) = show code ++ " " ++ B.unpack message
+renderHpackError _ (CycleInDefaultsError files) =
+  "cycle in defaults (" ++ intercalate " -> " files ++ ")"
+renderHpackError _ (HpackParseAesonException file s) = renderFileMsg file s
+renderHpackError _ (HpackParseYamlException file s) = renderFileMsg file s
+renderHpackError _ (HpackParseYamlParseException{..}) = renderFileMsg yamlFile $
+  show yamlLine ++ ":" ++ show yamlColumn ++ ": " ++ yamlProblem ++ " " ++ yamlContext
+renderHpackError _ (HpackParseOtherException file s) = renderFileMsg file s
+renderHpackError _ (DecodeValueError file s) = renderFileMsg file s
+renderHpackError _ (HpackOtherException file s) = renderFileMsg file s
+
+-- | Helper function for renderHpackError
+renderFileMsg :: FilePath -> String -> String
+renderFileMsg file s = file ++ ": " ++ s
+
+hpackProgName :: ProgramName
+hpackProgName = ProgramName "hpack"
+
+-- | Type representing the names of programs using the Hpack library.
+newtype ProgramName = ProgramName {unProgramName :: String}
+  deriving (Eq, Show)
+
+instance IsString ProgramName where
+  fromString = ProgramName

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.11
+resolver: lts-20.1

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 494638
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/15/11.yaml
-    sha256: 5747328cdcbb8fe9c96fc048b5566167c80dd176a41b52d3b363058e3cc1dc5d
-  original: lts-15.11
+    sha256: b73b2b116143aea728c70e65c3239188998bac5bc3be56465813dacd74215dc5
+    size: 648424
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/1.yaml
+  original: lts-20.1

--- a/test/Hpack/DefaultsSpec.hs
+++ b/test/Hpack/DefaultsSpec.hs
@@ -4,6 +4,7 @@ module Hpack.DefaultsSpec (spec) where
 import           Helper
 import           System.Directory
 
+import           Hpack.Error (HpackError (..))
 import           Hpack.Syntax.Defaults
 import           Hpack.Defaults
 
@@ -12,7 +13,7 @@ spec = do
   describe "ensure" $ do
     it "fails when local file does not exist" $ do
       cwd <- getCurrentDirectory
-      let expected = Left $ "Invalid value for \"defaults\"! File " ++ (cwd </> "foo") ++ " does not exist!"
+      let expected = Left (DefaultsFileNotFound $ cwd </> "foo")
       ensure undefined cwd (DefaultsLocal $ Local "foo") `shouldReturn` expected
 
   describe "ensureFile" $ do

--- a/test/HpackSpec.hs
+++ b/test/HpackSpec.hs
@@ -4,11 +4,13 @@ import           Helper
 
 import           Prelude hiding (readFile)
 import qualified Prelude as Prelude
+import           System.Exit (die)
 
 import           Control.DeepSeq
 
 import           Hpack.Config
 import           Hpack.CabalFile
+import           Hpack.Error (hpackProgName, renderHpackError)
 import           Hpack hiding (hpack)
 
 readFile :: FilePath -> IO String
@@ -55,7 +57,7 @@ spec = do
     let
       file = "foo.cabal"
 
-      hpackWithVersion v = hpackResultWithVersion (makeVersion v) defaultOptions
+      hpackWithVersion v = hpackResultWithVersion (makeVersion v) defaultOptions >>= either (die . renderHpackError hpackProgName) return
       hpackWithStrategy strategy = hpackResult defaultOptions { optionsGenerateHashStrategy = strategy }
       hpackForce = hpackResult defaultOptions {optionsForce = Force}
 


### PR DESCRIPTION
The `Show` instance for `HpackException` preserves the existing error messages of all existing Hpack exceptions.

Moves `ProgramName` from `Hpack.Config` to new module `Hpack.ProgramName` because `Hpack.Exception` needs to import the type and `Hpack.Config` now imports `Hpack.Exception`.

Also bumps Hpack's `stack.yaml` to use lts-20.0 (GHC 9.2.5) rather than lts-15.11 (GHC 8.8.3).