### PR TITLE
bump everything - all tests but 1 passing - windows

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -12,19 +12,19 @@ extra-source-files:
 ghc-options: -Wall -fno-warn-incomplete-uni-patterns
 
 dependencies:
-  - base >= 4.9 && < 5
+  - base
   - bytestring
   - deepseq
-  - directory >= 1.2.5.0
+  - directory
   - filepath
-  - Glob >= 0.9.0
+  - Glob
   - text
   - containers
   - unordered-containers
-  - yaml >= 0.10.0
-  - aeson >= 1.4.3.0
+  - yaml
+  - aeson
   - scientific
-  - Cabal >= 3.0.0.0 && < 3.9
+  - Cabal
   - pretty
   - bifunctors
   - cryptonite
@@ -33,7 +33,7 @@ dependencies:
   - http-client
   - http-client-tls
   - vector
-  - infer-license >= 0.2.0 && < 0.3
+  - infer-license
 
 library:
   source-dirs: src
@@ -58,11 +58,11 @@ tests:
       - test
       - src
     dependencies:
-      - hspec == 2.*
+      - hspec
       - QuickCheck
       - temporary
-      - mockery >= 0.3
+      - mockery 
       - interpolate
       - template-haskell
-      - HUnit >= 1.6.0.0
+      - HUnit
     build-tools: hspec-discover

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-15.11
+resolver: nightly-2023-02-23

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 494638
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/15/11.yaml
-    sha256: 5747328cdcbb8fe9c96fc048b5566167c80dd176a41b52d3b363058e3cc1dc5d
-  original: lts-15.11
+    sha256: 1f4620e9e6768c6d08bc95e644fb13a28464b430853b3cf944b8cd51ec62cecf
+    size: 598113
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2023/2/23.yaml
+  original: nightly-2023-02-23


### PR DESCRIPTION
hello,
I could not compile master on windows. ``stack build`` was failing with an access violation. I tried ``cabal build`` but failed with type errors.

So I tried a Hail Mary ditch constraints and and bump the resolver to Stackage Nightly ``2023-02-23 (ghc-9.4.4)``
on my windows machine ``stack build`` succeeds and all but 1 test pass when ``stack test`` is run
```
Failures:

  test\HpackSpec.hs:55:40: 
  1) Hpack.renderCabalFile is inverse to readCabalFile
       expected: ["../../hpack.cabal"]
        but got: ["../../hpack.cabal", "-- This file has been generated from package.yaml by hpack.", "--", "-- see: https://github.com/sol/hpack", ""]

  To rerun use: --match "/Hpack/renderCabalFile/is inverse to readCabalFile/"

Randomized with seed 927868982

Finished in 11.7191 seconds
546 examples, 1 failure, 3 pending
```

I suspect this test is failing because expected is wrong? 
the test is:
```haskell
  describe "renderCabalFile" $ do
    it "is inverse to readCabalFile" $ do
      expected <- lines <$> readFile "resources/test/hpack.cabal"
      Just c <- readCabalFile "resources/test/hpack.cabal"
      renderCabalFile "package.yaml" c `shouldBe` expected
```

the content of  ```resources/test/hpack.cabal``` is:
```
../../hpack.cabal
```
Does ```readFile``` somehow follow this link in other  OSs  and just return the content on windows?