### PR TITLE
Don't write out the cabal file if it matches the old one

### DIFF
--- a/src/Hpack.hs
+++ b/src/Hpack.hs
@@ -248,7 +248,7 @@ hpackResultWithVersion v (Options options force generateHashStrategy toStdout) =
           NoForce -> maybe Generated (mkStatus newCabalFile) mExistingCabalFile
 
       case status of
-        Generated -> writeCabalFile options toStdout cabalFileName newCabalFile
+        Generated -> writeCabalFile options toStdout cabalFileName mExistingCabalFile newCabalFile
         _ -> return ()
 
       return $ Right Result {
@@ -258,8 +258,9 @@ hpackResultWithVersion v (Options options force generateHashStrategy toStdout) =
       }
     Left err -> return $ Left err
 
-writeCabalFile :: DecodeOptions -> Bool -> FilePath -> CabalFile -> IO ()
-writeCabalFile options toStdout name cabalFile = do
+writeCabalFile :: DecodeOptions -> Bool -> FilePath -> Maybe CabalFile -> CabalFile -> IO ()
+writeCabalFile _ _ _ (Just oldCabalFile) newCabalFile | oldCabalFile == newCabalFile = mempty
+writeCabalFile options toStdout name _ cabalFile = do
   write . unlines $ renderCabalFile (decodeOptionsTarget options) cabalFile
   where
     write = if toStdout then Utf8.putStr else Utf8.writeFile name


### PR DESCRIPTION
The motivation behind this change is avoid the `--force` option from triggering an unnecessary reload of `ghcid` if nothing changed.

The context is that at work we use `hpack --force` to correct manual edits that users might make to the `.cabal` file, and we run `hpack --force` whenever users enter our Nix shell.  If a user uses `direnv` on top of that then `hpack --force` runs every time they `cd` to the project directory.

However, suppose that they load `ghcid` in one window and then `cd` to the project directory in another window.  This causes `hpack --force` to run and even if nothing changed the `mwb.cabal` file is touched which causes `ghcid` to reload (which is expensive).  This change fixes that.