### PR TITLE
 Fix a bug related to git conflict markers in existing `.cabal` files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Changes in 0.36.0
+ - When an existing `.cabal` does not align fields then do not align fields in
+   the generated `.cabal` file.
+
+ - Fix a bug related to git conflict markers in existing `.cabal` files: When a
+   `.cabal` file was essentially unchanged, but contained git conflict markers
+   then `hpack` did not write a new `.cabal` file at all.  To address this
+   `hpack` now unconditionally writes a new `.cabal` file when the existing
+   `.cabal` file contains any git conflict markers.
+
 ## Changes in 0.35.2
   - Add support for `ghc-shared-options`
 

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,0 +1,3 @@
+cradle:
+  cabal:
+    component: hpack:test:spec

--- a/hpack.cabal
+++ b/hpack.cabal
@@ -11,6 +11,7 @@ description:    See README at <https://github.com/sol/hpack#readme>
 category:       Development
 homepage:       https://github.com/sol/hpack#readme
 bug-reports:    https://github.com/sol/hpack/issues
+author:         Simon Hengel <sol@typeful.net>
 maintainer:     Simon Hengel <sol@typeful.net>
 license:        MIT
 license-file:   LICENSE

--- a/package.yaml
+++ b/package.yaml
@@ -2,6 +2,7 @@ name: hpack
 version: 0.35.3
 synopsis: A modern format for Haskell packages
 description: See README at <https://github.com/sol/hpack#readme>
+author: Simon Hengel <sol@typeful.net>
 maintainer: Simon Hengel <sol@typeful.net>
 github: sol/hpack
 category: Development

--- a/src/Hpack/Render/Hints.hs
+++ b/src/Hpack/Render/Hints.hs
@@ -68,16 +68,31 @@ unindent input = map (drop indentation) input
   where
     indentation = minimum $ map (length . takeWhile isSpace) input
 
-sniffAlignment :: [String] -> Maybe Alignment
-sniffAlignment input = case nub . catMaybes . map indentation . catMaybes . map splitField $ input of
-  [n] -> Just (Alignment n)
-  _ -> Nothing
-  where
+data Indentation = Indentation {
+  indentationFieldNameLength :: Int
+, indentationPadding :: Int
+}
 
-    indentation :: (String, String) -> Maybe Int
+indentationTotal :: Indentation -> Int
+indentationTotal (Indentation fieldName padding) = fieldName + padding
+
+sniffAlignment :: [String] -> Maybe Alignment
+sniffAlignment input
+  | all (indentationPadding >>> (== 1)) indentations = Just 0
+  | otherwise = case nub (map indentationTotal indentations) of
+      [n] -> Just (Alignment n)
+      _ -> Nothing
+  where
+    indentations :: [Indentation]
+    indentations = catMaybes . map (splitField >=> indentation) $ input
+
+    indentation :: (String, String) -> Maybe Indentation
     indentation (name, value) = case span isSpace value of
       (_, "") -> Nothing
-      (xs, _) -> (Just . succ . length $ name ++ xs)
+      (padding, _) -> Just Indentation {
+        indentationFieldNameLength = succ $ length name
+      , indentationPadding = length padding
+      }
 
 splitField :: String -> Maybe (String, String)
 splitField field = case span isNameChar field of

--- a/test/Helper.hs
+++ b/test/Helper.hs
@@ -11,6 +11,7 @@ module Helper (
 , module System.FilePath
 , withCurrentDirectory
 , yaml
+, makeVersion
 ) where
 
 import           Imports
@@ -19,6 +20,7 @@ import           Test.Hspec
 import           Test.Mockery.Directory
 import           Control.Monad
 import           Control.Applicative
+import           Data.Version (Version(..))
 import           System.Directory (getCurrentDirectory, setCurrentDirectory, canonicalizePath)
 import           Control.Exception
 import qualified System.IO.Temp as Temp
@@ -44,3 +46,6 @@ withTempDirectory action = Temp.withSystemTempDirectory "hspec" $ \dir -> do
 
 yaml :: Language.Haskell.TH.Quote.QuasiQuoter
 yaml = yamlQQ
+
+makeVersion :: [Int] -> Version
+makeVersion v = Version v []

--- a/test/Hpack/CabalFileSpec.hs
+++ b/test/Hpack/CabalFileSpec.hs
@@ -28,12 +28,12 @@ spec = do
     it "includes hash" $ do
       inTempDirectory $ do
         writeFile file $ mkHeader "package.yaml" version hash
-        readCabalFile file `shouldReturn` Just (CabalFile [] (Just version) (Just hash) [])
+        readCabalFile file `shouldReturn` Just (CabalFile [] (Just version) (Just hash) [] DoesNotHaveGitConflictMarkers)
 
     it "accepts cabal-version at the beginning of the file" $ do
       inTempDirectory $ do
         writeFile file $ ("cabal-version: 2.2\n" ++ mkHeader "package.yaml" version hash)
-        readCabalFile file `shouldReturn` Just (CabalFile ["cabal-version: 2.2"] (Just version) (Just hash) [])
+        readCabalFile file `shouldReturn` Just (CabalFile ["cabal-version: 2.2"] (Just version) (Just hash) [] DoesNotHaveGitConflictMarkers)
 
   describe "extractVersion" $ do
     it "extracts Hpack version from a cabal file" $ do

--- a/test/Hpack/Render/HintsSpec.hs
+++ b/test/Hpack/Render/HintsSpec.hs
@@ -21,7 +21,7 @@ spec = do
   describe "extractFieldOrder" $ do
     it "extracts field order hints" $ do
       let input = [
-              "name:           cabalize"
+              "name:           hpack"
             , "version:        0.0.0"
             , "license:"
             , "license-file: "
@@ -38,7 +38,7 @@ spec = do
   describe "extractSectionsFieldOrder" $ do
     it "splits input into sections" $ do
       let input = [
-              "name:           cabalize"
+              "name:           hpack"
             , "version:        0.0.0"
             , ""
             , "library"
@@ -88,7 +88,7 @@ spec = do
   describe "sniffAlignment" $ do
     it "sniffs field alignment from given cabal file" $ do
       let input = [
-              "name:           cabalize"
+              "name:           hpack"
             , "version:        0.0.0"
             , "license:        MIT"
             , "license-file:   LICENSE"
@@ -98,13 +98,24 @@ spec = do
 
     it "ignores fields without a value on the same line" $ do
       let input = [
-              "name:           cabalize"
+              "name:           hpack"
             , "version:        0.0.0"
             , "description: "
             , "  foo"
             , "  bar"
             ]
       sniffAlignment input `shouldBe` Just 16
+
+    context "when all fields are padded with exactly one space" $ do
+      it "returns 0" $ do
+        let input = [
+                "name: hpack"
+              , "version: 0.0.0"
+              , "license: MIT"
+              , "license-file: LICENSE"
+              , "build-type: Simple"
+              ]
+        sniffAlignment input `shouldBe` Just 0
 
   describe "splitField" $ do
     it "splits fields" $ do


### PR DESCRIPTION
 When a `.cabal` file was essentially unchanged, but contained git
 conflict markers then `hpack` did not write a new `.cabal` file at
 all.  To address this `hpack` now unconditionally writes a new `.cabal`
 file when the existing `.cabal` file contains any git conflict markers.