### PR TITLE
Desugar local build tools to `build-tool-depends` (fixes #516)

### DIFF
--- a/src/Hpack/Render.hs
+++ b/src/Hpack/Render.hs
@@ -351,7 +351,6 @@ data RenderBuildTool = BuildTools String | BuildToolDepends String
 
 renderBuildTool :: (BuildTool,  DependencyVersion) -> RenderBuildTool
 renderBuildTool (buildTool, renderVersion -> version) = case buildTool of
-  LocalBuildTool executable -> BuildTools (executable ++ version)
   BuildTool pkg executable
     | pkg == executable && executable `elem` knownBuildTools -> BuildTools (executable ++ version)
     | otherwise -> BuildToolDepends (pkg ++ ":" ++ executable ++ version)

--- a/test/EndToEndSpec.hs
+++ b/test/EndToEndSpec.hs
@@ -668,15 +668,15 @@ spec = around_ (inTempDirectoryNamed "my-package") $ do
         }
 
       context "when the name of a build tool matches an executable from the same package" $ do
-        it "adds it to build-tools" $ do
+        it "adds it to build-tool-depends" $ do
           [i|
           executables:
             bar:
               build-tools:
                 - bar
           |] `shouldRenderTo` executable_ "bar" [i|
-          build-tools:
-              bar
+          build-tool-depends:
+              my-package:bar
           |]
 
         it "gives per-section unqualified names precedence over global qualified names" $ do
@@ -688,8 +688,8 @@ spec = around_ (inTempDirectoryNamed "my-package") $ do
               build-tools:
                 - bar == 0.2.0
           |] `shouldRenderTo` executable_ "bar" [i|
-          build-tools:
-              bar ==0.2.0
+          build-tool-depends:
+              my-package:bar ==0.2.0
           |]
 
         it "gives per-section qualified names precedence over global unqualified names" $ do
@@ -701,8 +701,8 @@ spec = around_ (inTempDirectoryNamed "my-package") $ do
               build-tools:
                 - my-package:bar == 0.2.0
           |] `shouldRenderTo` executable_ "bar" [i|
-          build-tools:
-              bar ==0.2.0
+          build-tool-depends:
+              my-package:bar ==0.2.0
           |]
 
       context "when the name of a build tool matches a legacy system build tool" $ do

--- a/test/Hpack/ConfigSpec.hs
+++ b/test/Hpack/ConfigSpec.hs
@@ -157,8 +157,8 @@ spec = do
           toBuildTool_ (UnqualifiedBuildTool "bar") `shouldBe` (Right (BuildTool "bar" "bar", anyVersion), [])
 
       context "when name matches a local executable" $ do
-        it "returns a LocalBuildTool" $ do
-          toBuildTool_ (UnqualifiedBuildTool "foo") `shouldBe` (Right (LocalBuildTool "foo", anyVersion), [])
+        it "uses the current package name" $ do
+          toBuildTool_ (UnqualifiedBuildTool "foo") `shouldBe` (Right (BuildTool "my-package" "foo", anyVersion), [])
 
       context "when name matches a legacy executable" $ do
         it "warns" $ do
@@ -176,10 +176,6 @@ spec = do
       context "when only executable matches a local executable" $ do
         it "returns a BuildTool" $ do
           toBuildTool_ (QualifiedBuildTool "other-package" "foo") `shouldBe` (Right (BuildTool "other-package" "foo", anyVersion), [])
-
-      context "when both package matches the current package and executable matches a local executable" $ do
-        it "returns a LocalBuildTool" $ do
-          toBuildTool_ (QualifiedBuildTool "my-package" "foo") `shouldBe` (Right (LocalBuildTool "foo", anyVersion), [])
 
   describe "readPackageConfig" $ do
     it "warns on missing name" $ do


### PR DESCRIPTION
- This has the potential to break packages for `cabal v1-`, and Hackage still uses `cabal v1-`: https://github.com/haskell/hackage-server/issues/821
- At first glance you might think that cabal files that use `build-tool-depends` should specify at least `cabal-version: 2.0`, however, that's not strictly true, see: [`build-tools`](https://cabal.readthedocs.io/en/stable/cabal-package.html#pkg-field-build-tools) and [`build-tool-depends`](https://cabal.readthedocs.io/en/stable/cabal-package.html#pkg-field-build-tool-depends)