### PR TITLE
Hide Data.List.List import

### DIFF
--- a/src/Imports.hs
+++ b/src/Imports.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Imports (module Imports) where
 
 import           Control.Applicative as Imports
@@ -6,7 +7,11 @@ import           Control.Exception as Imports (Exception(..))
 import           Control.Monad as Imports
 import           Control.Monad.IO.Class as Imports
 import           Data.Bifunctor as Imports
+#if MIN_VERSION_base(4,20,0)
+import           Data.List as Imports hiding (List, sort, nub)
+#else
 import           Data.List as Imports hiding (sort, nub)
+#endif
 import           Data.Monoid as Imports (Monoid(..))
 import           Data.Semigroup as Imports (Semigroup(..))
 import           Data.String as Imports


### PR DESCRIPTION
This PR hides the `Data.List.List` identifier from the Data.List import in Imports.hs.

Since the identifier will arrive with [base-4.20.0.0](https://gitlab.haskell.org/ghc/ghc/-/blob/2776920e642544477a38d0ed9205d4f0b48a782e/libraries/base/changelog.md#42000-tba), this hiding is guarded behind a CPP conditional.