### PR TITLE
Fix #575 Accommodate `GHC2024`

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ values are merged with per section values.
 | `buildable` | · | | Per section takes precedence over top-level |
 | `source-dirs` | `hs-source-dirs` | | |
 | `default-extensions` | · | | |
-| `language` | `default-language` | `Haskell2010` | Also accepts `Haskell98` or `GHC2021`. Per section takes precedence over top-level |
+| `language` | `default-language` | `Haskell2010` | Also accepts `Haskell98`, `GHC2021` or `GHC2024`. Per section takes precedence over top-level |
 | `other-extensions` | · | | |
 | `ghc-options` | · | | |
 | `ghc-prof-options` | · | | |


### PR DESCRIPTION
This only requires an update to `README.md` because, in fact, Hpack itself already accepts any string for the `language`.