### PR TITLE
Fix #355 Add support for `includes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changes in 0.37.0
   - Add support for `asm-options` and `asm-sources` (see #573)
+  - Add support for `includes` (see #355)
 
 ## Changes in 0.36.1
   - Allow `Cabal-3.12.*`

--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ values are merged with per section values.
 | `extra-lib-dirs` | · | | |
 | `extra-libraries` | · | | |
 | `include-dirs` | · | | |
+| `includes` | · | | |
 | `install-includes` | · | | |
 | `frameworks` | · | | |
 | `extra-frameworks-dirs` | · | | |

--- a/src/Hpack/Config.hs
+++ b/src/Hpack/Config.hs
@@ -192,7 +192,7 @@ packageDependencies Package{..} = nub . sortBy (comparing (lexicographically . f
     deps xs = [(name, info) | (name, info) <- (Map.toList . unDependencies . sectionDependencies) xs]
 
 section :: a -> Section a
-section a = Section a [] mempty [] [] [] Nothing [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] Nothing [] mempty mempty []
+section a = Section a [] mempty [] [] [] Nothing [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] Nothing [] mempty mempty []
 
 packageConfig :: FilePath
 packageConfig = "package.yaml"
@@ -296,6 +296,7 @@ data CommonOptions asmSources cSources cxxSources jsSources a = CommonOptions {
 , commonOptionsExtraFrameworksDirs :: Maybe (List FilePath)
 , commonOptionsFrameworks :: Maybe (List String)
 , commonOptionsIncludeDirs :: Maybe (List FilePath)
+, commonOptionsIncludes :: Maybe (List FilePath)
 , commonOptionsInstallIncludes :: Maybe (List FilePath)
 , commonOptionsLdOptions :: Maybe (List LdOption)
 , commonOptionsBuildable :: Last Bool
@@ -333,6 +334,7 @@ instance (Semigroup asmSources, Semigroup cSources, Semigroup cxxSources, Semigr
   , commonOptionsExtraFrameworksDirs = Nothing
   , commonOptionsFrameworks = Nothing
   , commonOptionsIncludeDirs = Nothing
+  , commonOptionsIncludes = Nothing
   , commonOptionsInstallIncludes = Nothing
   , commonOptionsLdOptions = Nothing
   , commonOptionsBuildable = mempty
@@ -368,6 +370,7 @@ instance (Semigroup asmSources, Semigroup cSources, Semigroup cxxSources, Semigr
   , commonOptionsExtraFrameworksDirs = commonOptionsExtraFrameworksDirs a <> commonOptionsExtraFrameworksDirs b
   , commonOptionsFrameworks = commonOptionsFrameworks a <> commonOptionsFrameworks b
   , commonOptionsIncludeDirs = commonOptionsIncludeDirs a <> commonOptionsIncludeDirs b
+  , commonOptionsIncludes = commonOptionsIncludes a <> commonOptionsIncludes b
   , commonOptionsInstallIncludes = commonOptionsInstallIncludes a <> commonOptionsInstallIncludes b
   , commonOptionsLdOptions = commonOptionsLdOptions a <> commonOptionsLdOptions b
   , commonOptionsBuildable = commonOptionsBuildable a <> commonOptionsBuildable b
@@ -1044,6 +1047,7 @@ data Section a = Section {
 , sectionExtraFrameworksDirs :: [FilePath]
 , sectionFrameworks :: [FilePath]
 , sectionIncludeDirs :: [FilePath]
+, sectionIncludes :: [FilePath]
 , sectionInstallIncludes :: [FilePath]
 , sectionLdOptions :: [LdOption]
 , sectionBuildable :: Maybe Bool
@@ -1543,6 +1547,7 @@ toSection packageName_ executableNames = go
       , sectionExtraFrameworksDirs = fromMaybeList commonOptionsExtraFrameworksDirs
       , sectionFrameworks = fromMaybeList commonOptionsFrameworks
       , sectionIncludeDirs = fromMaybeList commonOptionsIncludeDirs
+      , sectionIncludes = fromMaybeList commonOptionsIncludes
       , sectionInstallIncludes = fromMaybeList commonOptionsInstallIncludes
       , sectionLdOptions = fromMaybeList commonOptionsLdOptions
       , sectionBuildable = getLast commonOptionsBuildable

--- a/src/Hpack/Render.hs
+++ b/src/Hpack/Render.hs
@@ -238,6 +238,7 @@ renderSection renderSectionData extraFieldsStart Section{..} = addVerbatim secti
   , renderCcOptions sectionCcOptions
   , renderCxxOptions sectionCxxOptions
   , renderDirectories "include-dirs" sectionIncludeDirs
+  , Field "includes" (LineSeparatedList sectionIncludes)
   , Field "install-includes" (LineSeparatedList sectionInstallIncludes)
   , Field "asm-sources" (renderPaths sectionAsmSources)
   , Field "c-sources" (renderPaths sectionCSources)

--- a/test/EndToEndSpec.hs
+++ b/test/EndToEndSpec.hs
@@ -877,6 +877,19 @@ spec = around_ (inTempDirectoryNamed "my-package") $ do
             bar
         |]
 
+    describe "includes" $ do
+      it "accepts includes" $ do
+        [i|
+        includes:
+          - foo.h
+          - bar.h
+        executable: {}
+        |] `shouldRenderTo` executable_ "my-package" [i|
+        includes:
+            foo.h
+            bar.h
+        |]
+
     describe "install-includes" $ do
       it "accepts install-includes" $ do
         [i|


### PR DESCRIPTION
Follows the pattern of existing `install-includes`. Fixes:
* #355

EDIT: A test added, again following `install-includes`. 