### PR TITLE
Fix #573 Add support for `asm-options` and `asm-sources`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Changes in 0.37.0
+  - Add support for `asm-options` and `asm-sources` (see #573)
+
 ## Changes in 0.36.1
   - Allow `Cabal-3.12.*`
   - Support `base >= 4.20.0` (`Imports` does not re-export `Data.List.List`)

--- a/README.md
+++ b/README.md
@@ -251,6 +251,8 @@ values are merged with per section values.
 | `ghc-shared-options` | · | | |
 | `ghcjs-options` | · | | |
 | `cpp-options` | · | | |
+| `asm-options` | · | | |
+| `asm-sources` | · | | Accepts [glob patterns](#file-globbing) |
 | `cc-options` | · | | |
 | `c-sources` | · | | Accepts [glob patterns](#file-globbing) |
 | `cxx-options` | · | | |

--- a/src/Hpack/Render.hs
+++ b/src/Hpack/Render.hs
@@ -234,10 +234,12 @@ renderSection renderSectionData extraFieldsStart Section{..} = addVerbatim secti
   , renderGhcSharedOptions sectionGhcSharedOptions
   , renderGhcjsOptions sectionGhcjsOptions
   , renderCppOptions sectionCppOptions
+  , renderAsmOptions sectionAsmOptions
   , renderCcOptions sectionCcOptions
   , renderCxxOptions sectionCxxOptions
   , renderDirectories "include-dirs" sectionIncludeDirs
   , Field "install-includes" (LineSeparatedList sectionInstallIncludes)
+  , Field "asm-sources" (renderPaths sectionAsmSources)
   , Field "c-sources" (renderPaths sectionCSources)
   , Field "cxx-sources" (renderPaths sectionCxxSources)
   , Field "js-sources" (renderPaths sectionJsSources)
@@ -391,6 +393,9 @@ renderGhcjsOptions = Field "ghcjs-options" . WordList
 
 renderCppOptions :: [CppOption] -> Element
 renderCppOptions = Field "cpp-options" . WordList
+
+renderAsmOptions :: [AsmOption] -> Element
+renderAsmOptions = Field "asm-options" . WordList
 
 renderCcOptions :: [CcOption] -> Element
 renderCcOptions = Field "cc-options" . WordList

--- a/src/Hpack/Util.hs
+++ b/src/Hpack/Util.hs
@@ -4,6 +4,7 @@ module Hpack.Util (
 , GhcProfOption
 , GhcjsOption
 , CppOption
+, AsmOption
 , CcOption
 , CxxOption
 , LdOption
@@ -46,6 +47,7 @@ type GhcOption = String
 type GhcProfOption = String
 type GhcjsOption = String
 type CppOption = String
+type AsmOption = String
 type CcOption = String
 type CxxOption = String
 type LdOption = String

--- a/test/EndToEndSpec.hs
+++ b/test/EndToEndSpec.hs
@@ -924,6 +924,32 @@ spec = around_ (inTempDirectoryNamed "my-package") $ do
             jsbits/bar.js
         |]
 
+    describe "asm-options" $ do
+      it "accepts asm-options" $ do
+        [i|
+        executable:
+          asm-options: -Wall
+        |] `shouldRenderTo` (executable_ "my-package" [i|
+        autogen-modules:
+            Paths_my_package
+        asm-options: -Wall
+        |]) {packageCabalVersion = "3.0"}
+
+    describe "asm-sources" $ before_ (touch "foo.asm" >> touch "asmbits/bar.asm") $ do
+      it "accepts asm-sources" $ do
+        [i|
+        executable:
+          asm-sources:
+            - foo.asm
+            - asmbits/*.asm
+        |] `shouldRenderTo` (executable_ "my-package" [i|
+        autogen-modules:
+            Paths_my_package
+        asm-sources:
+            foo.asm
+            asmbits/bar.asm
+        |]) {packageCabalVersion = "3.0"}
+
     describe "cxx-options" $ do
       it "accepts cxx-options" $ do
         [i|


### PR DESCRIPTION
Follows the pattern of existing `cc-options` and `c-sources`, except for tests (follows `cxx-options` and `cxx-sources`). Fixes:
* #573 