### PR TITLE
Implement `extra-files`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+  - Add support for `extra-files` (see #603)
 
 ## Changes in 0.38.0
   - Generate `build-tool-depends` instead of `build-tools` starting with

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ library:
 | `build-type` | · | `Simple`, or `Custom` if `custom-setup` exists | Must be `Simple`, `Configure`, `Make`, or `Custom` | | |
 | `extra-source-files` | · | | Accepts [glob patterns](#file-globbing) | | |
 | `extra-doc-files` | · | | Accepts [glob patterns](#file-globbing) | | `0.21.2` |
+| `extra-files` | · | | Accepts [glob patterns](#file-globbing) | | UNRELEASED |
 | `data-files` | · | | Accepts [glob patterns](#file-globbing) | | |
 | `data-dir` | · | | | | |
 | `github` | `source-repository head` | | Accepts `owner/repo` or `owner/repo/subdir` | `github: foo/bar` |

--- a/src/Hpack/Config.hs
+++ b/src/Hpack/Config.hs
@@ -160,6 +160,7 @@ package name version = Package {
   , packageFlags = []
   , packageExtraSourceFiles = []
   , packageExtraDocFiles = []
+  , packageExtraFiles = []
   , packageDataFiles = []
   , packageDataDir = Nothing
   , packageSourceRepository = Nothing
@@ -602,6 +603,7 @@ data PackageConfig_ library executable = PackageConfig {
 , packageConfigFlags :: Maybe (Map String FlagSection)
 , packageConfigExtraSourceFiles :: Maybe (List FilePath)
 , packageConfigExtraDocFiles :: Maybe (List FilePath)
+, packageConfigExtraFiles :: Maybe (List FilePath)
 , packageConfigDataFiles :: Maybe (List FilePath)
 , packageConfigDataDir :: Maybe FilePath
 , packageConfigGithub :: Maybe GitHub
@@ -831,6 +833,7 @@ ensureRequiredCabalVersion inferredLicense pkg@Package{..} = pkg {
         makeVersion [2,2] <$ guard mustSPDX
       , makeVersion [1,24] <$ packageCustomSetup
       , makeVersion [1,18] <$ guard (not (null packageExtraDocFiles))
+      , makeVersion [3,14] <$ guard (not (null packageExtraFiles))
       , packageLibrary >>= libraryCabalVersion
       , internalLibsCabalVersion packageInternalLibraries
       , executablesCabalVersion packageExecutables
@@ -1024,6 +1027,7 @@ data Package = Package {
 , packageFlags :: [Flag]
 , packageExtraSourceFiles :: [Path]
 , packageExtraDocFiles :: [Path]
+, packageExtraFiles :: [Path]
 , packageDataFiles :: [Path]
 , packageDataDir :: Maybe FilePath
 , packageSourceRepository :: Maybe SourceRepository
@@ -1272,6 +1276,7 @@ toPackage_ dir (Product g PackageConfig{..}) = do
 
   extraSourceFiles <- expandGlobs "extra-source-files" dir (fromMaybeList packageConfigExtraSourceFiles)
   extraDocFiles <- expandGlobs "extra-doc-files" dir (fromMaybeList packageConfigExtraDocFiles)
+  extraFiles <- expandGlobs "extra-files" dir (fromMaybeList packageConfigExtraFiles)
 
   let dataBaseDir = maybe dir (dir </>) packageConfigDataDir
 
@@ -1316,6 +1321,7 @@ toPackage_ dir (Product g PackageConfig{..}) = do
       , packageFlags = flags
       , packageExtraSourceFiles = extraSourceFiles
       , packageExtraDocFiles = extraDocFiles
+      , packageExtraFiles = extraFiles
       , packageDataFiles = dataFiles
       , packageDataDir = packageConfigDataDir
       , packageSourceRepository = sourceRepository

--- a/src/Hpack/Render.hs
+++ b/src/Hpack/Render.hs
@@ -84,6 +84,7 @@ renderPackageWith settings headerFieldsAlignment existingFieldOrder sectionsFiel
         Field "tested-with" $ CommaSeparatedList packageTestedWith
       , Field "extra-source-files" (renderPaths packageExtraSourceFiles)
       , Field "extra-doc-files" (renderPaths packageExtraDocFiles)
+      , Field "extra-files" (renderPaths packageExtraFiles)
       , Field "data-files" (renderPaths packageDataFiles)
       ] ++ maybe [] (return . Field "data-dir" . Literal) packageDataDir
 

--- a/test/EndToEndSpec.hs
+++ b/test/EndToEndSpec.hs
@@ -638,6 +638,20 @@ spec = around_ (inTempDirectoryNamed "my-package") $ do
           - "*.markdown"
         |] `shouldWarn` ["Specified pattern \"*.markdown\" for extra-doc-files does not match any files"]
 
+    describe "extra-files" $ do
+      it "accepts a list of files" $ do
+        touch "CHANGES.markdown"
+        touch "README.markdown"
+        [i|
+        extra-files:
+          - CHANGES.markdown
+          - README.markdown
+        |] `shouldRenderTo` (package [i|
+        extra-files:
+            CHANGES.markdown
+            README.markdown
+        |]) {packageCabalVersion = "3.14"}
+
     describe "build-tools" $ do
       context "with known build tools" $ do
         context "when cabal-version < 2" $ do


### PR DESCRIPTION
`cabal-version: 3.14` of the Cabal package description format specification has [introduced](https://cabal.readthedocs.io/en/stable/file-format-changelog.html#cabal-version-3-14) new field [`extra-files`](https://cabal.readthedocs.io/en/stable/cabal-package-description-file.html#pkg-field-extra-files) - like `extra-source-files` but without the semantics that the files listed are tracked by build tools.