### PR TITLE
Update hpack.cabal to file generated by `main` branch version of Hpack

### DIFF
--- a/hpack.cabal
+++ b/hpack.cabal
@@ -25,33 +25,6 @@ source-repository head
   location: https://github.com/sol/hpack
 
 library
-  hs-source-dirs:
-      src
-  ghc-options: -Wall -fno-warn-incomplete-uni-patterns
-  build-depends:
-      Cabal >=3.0.0.0 && <3.13
-    , Glob >=0.9.0
-    , aeson >=1.4.3.0
-    , base >=4.13 && <5
-    , bifunctors
-    , bytestring
-    , containers
-    , crypton
-    , deepseq
-    , directory >=1.2.5.0
-    , filepath
-    , http-client
-    , http-client-tls >=0.3.6.2
-    , http-types
-    , infer-license >=0.2.0 && <0.3
-    , mtl
-    , pretty
-    , scientific
-    , text
-    , transformers
-    , unordered-containers
-    , vector
-    , yaml >=0.10.0
   exposed-modules:
       Hpack
       Hpack.Config
@@ -86,6 +59,33 @@ library
       Paths_hpack
   autogen-modules:
       Paths_hpack
+  hs-source-dirs:
+      src
+  ghc-options: -Wall -fno-warn-incomplete-uni-patterns
+  build-depends:
+      Cabal >=3.0.0.0 && <3.13
+    , Glob >=0.9.0
+    , aeson >=1.4.3.0
+    , base >=4.13 && <5
+    , bifunctors
+    , bytestring
+    , containers
+    , crypton
+    , deepseq
+    , directory >=1.2.5.0
+    , filepath
+    , http-client
+    , http-client-tls >=0.3.6.2
+    , http-types
+    , infer-license >=0.2.0 && <0.3
+    , mtl
+    , pretty
+    , scientific
+    , text
+    , transformers
+    , unordered-containers
+    , vector
+    , yaml >=0.10.0
   default-language: Haskell2010
   if impl(ghc >= 9.4.5) && os(windows)
     build-depends:
@@ -129,44 +129,6 @@ executable hpack
 test-suite spec
   type: exitcode-stdio-1.0
   main-is: Spec.hs
-  hs-source-dirs:
-      test
-      src
-  ghc-options: -Wall -fno-warn-incomplete-uni-patterns
-  cpp-options: -DTEST
-  build-depends:
-      Cabal >=3.0.0.0 && <3.13
-    , Glob >=0.9.0
-    , HUnit >=1.6.0.0
-    , QuickCheck
-    , aeson >=1.4.3.0
-    , base >=4.13 && <5
-    , bifunctors
-    , bytestring
-    , containers
-    , crypton
-    , deepseq
-    , directory >=1.2.5.0
-    , filepath
-    , hspec ==2.*
-    , http-client
-    , http-client-tls >=0.3.6.2
-    , http-types
-    , infer-license >=0.2.0 && <0.3
-    , interpolate
-    , mockery >=0.3
-    , mtl
-    , pretty
-    , scientific
-    , template-haskell
-    , temporary
-    , text
-    , transformers
-    , unordered-containers
-    , vector
-    , yaml >=0.10.0
-  build-tool-depends:
-      hspec-discover:hspec-discover
   other-modules:
       Data.Aeson.Config.FromValueSpec
       Data.Aeson.Config.TypesSpec
@@ -222,6 +184,44 @@ test-suite spec
       Paths_hpack
   autogen-modules:
       Paths_hpack
+  hs-source-dirs:
+      test
+      src
+  ghc-options: -Wall -fno-warn-incomplete-uni-patterns
+  cpp-options: -DTEST
+  build-tool-depends:
+      hspec-discover:hspec-discover
+  build-depends:
+      Cabal >=3.0.0.0 && <3.13
+    , Glob >=0.9.0
+    , HUnit >=1.6.0.0
+    , QuickCheck
+    , aeson >=1.4.3.0
+    , base >=4.13 && <5
+    , bifunctors
+    , bytestring
+    , containers
+    , crypton
+    , deepseq
+    , directory >=1.2.5.0
+    , filepath
+    , hspec ==2.*
+    , http-client
+    , http-client-tls >=0.3.6.2
+    , http-types
+    , infer-license >=0.2.0 && <0.3
+    , interpolate
+    , mockery >=0.3
+    , mtl
+    , pretty
+    , scientific
+    , template-haskell
+    , temporary
+    , text
+    , transformers
+    , unordered-containers
+    , vector
+    , yaml >=0.10.0
   default-language: Haskell2010
   if impl(ghc >= 9.4.5) && os(windows)
     build-depends:


### PR DESCRIPTION
The `main` branch version of Hpack renders `hpack.cabal` differently from the file in the repository.