### PR TITLE
Add 'Hooks' to the build-types (since cabal 3.14)

### DIFF
--- a/src/Hpack/Config.hs
+++ b/src/Hpack/Config.hs
@@ -548,6 +548,7 @@ data BuildType =
   | Configure
   | Make
   | Custom
+  | Hooks
   deriving (Eq, Show, Enum, Bounded)
 
 instance FromValue BuildType where


### PR DESCRIPTION
Cabal `>=3.14`, introduced `Hooks` build type that supposed to be the replacement for old `Setup.hs` stuff. This little patch just adds that to the `BuildType` data type so users can start using it.