### PR TITLE
Relax upper bound of dependency on Cabal

### DIFF
--- a/hpack.cabal
+++ b/hpack.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.38.0.
+-- This file has been generated from package.yaml by hpack version 0.38.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -63,7 +63,7 @@ library
       src
   ghc-options: -Wall -fno-warn-incomplete-uni-patterns
   build-depends:
-      Cabal >=3.0.0.0 && <3.15
+      Cabal >=3.0.0.0 && <3.17
     , Glob >=0.9.0
     , aeson >=1.4.3.0
     , base >=4.13 && <5
@@ -97,7 +97,7 @@ executable hpack
       driver
   ghc-options: -Wall -fno-warn-incomplete-uni-patterns
   build-depends:
-      Cabal >=3.0.0.0 && <3.15
+      Cabal >=3.0.0.0 && <3.17
     , Glob >=0.9.0
     , aeson >=1.4.3.0
     , base >=4.13 && <5
@@ -193,7 +193,7 @@ test-suite spec
   build-tool-depends:
       hspec-discover:hspec-discover
   build-depends:
-      Cabal >=3.0.0.0 && <3.15
+      Cabal >=3.0.0.0 && <3.17
     , Glob >=0.9.0
     , HUnit >=1.6.0.0
     , QuickCheck

--- a/package.yaml
+++ b/package.yaml
@@ -26,7 +26,7 @@ dependencies:
   - yaml >= 0.10.0
   - aeson >= 1.4.3.0
   - scientific
-  - Cabal >= 3.0.0.0 && < 3.15
+  - Cabal >= 3.0.0.0 && < 3.17
   - pretty
   - bifunctors
   - crypton


### PR DESCRIPTION
Tested by building Stack against `Cabal-3.16.0.0`.