### PR TITLE
Fix #622 Handle multi-line value for field description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Changes in 0.38.4
+  - Handle a multi-line value for the `description` key of a flag (see #623)
+
 ## Changes in 0.38.3
   - Accept a list for `category` (see #624)
 

--- a/hpack.cabal
+++ b/hpack.cabal
@@ -1,11 +1,11 @@
 cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.38.1.
+-- This file has been generated from package.yaml by hpack version 0.38.2.
 --
 -- see: https://github.com/sol/hpack
 
 name:           hpack
-version:        0.38.3
+version:        0.38.4
 synopsis:       A modern format for Haskell packages
 description:    See README at <https://github.com/sol/hpack#readme>
 category:       Development

--- a/package.yaml
+++ b/package.yaml
@@ -1,6 +1,6 @@
 spec-version: 0.36.0
 name: hpack
-version: 0.38.3
+version: 0.38.4
 synopsis: A modern format for Haskell packages
 description: See README at <https://github.com/sol/hpack#readme>
 author: Simon Hengel <sol@typeful.net>

--- a/test/Hpack/RenderSpec.hs
+++ b/test/Hpack/RenderSpec.hs
@@ -274,7 +274,7 @@ spec = do
   describe "renderFlag" $ do
     it "renders flags" $ do
       let flag = (Flag "foo" (Just "some flag") True False)
-      render defaultRenderSettings 0 (renderFlag flag) `shouldBe` [
+      render defaultRenderSettings 0 (renderFlag cabalVersion flag) `shouldBe` [
           "flag foo"
         , "  description: some flag"
         , "  manual: True"


### PR DESCRIPTION
See:
* #622 

This uses `LineSeparatedList` so that:
~~~yaml
flags:
  my-flag:
    description: |
      This is some text

      This is more some text
    manual: true
    default: true
~~~

renders as:
~~~yaml
flag my-flag
  description:
      This is some text
      .
      This is more some text
  manual: True
  default: True
~~~

otherwise I could not see how to avoid ugly rendering.