### PR TITLE
Fix typos

### DIFF
--- a/src/Hpack/Config.hs
+++ b/src/Hpack/Config.hs
@@ -1678,7 +1678,7 @@ toBuildTool packageName_ executableNames = \ case
       , "nix-build"
       ]
     warnLegacyTool pkg name = tell ["Usage of the unqualified build-tool name " ++ show name ++ " is deprecated! Please use the qualified name \"" ++ pkg ++ ":" ++ name ++ "\" instead!"]
-    warnLegacySystemTool name = tell ["Listing " ++ show name ++ " under build-tools is deperecated! Please list system executables under system-build-tools instead!"]
+    warnLegacySystemTool name = tell ["Listing " ++ show name ++ " under build-tools is deprecated! Please list system executables under system-build-tools instead!"]
 
 pathsModuleFromPackageName :: String -> Module
 pathsModuleFromPackageName name =

--- a/test/EndToEndSpec.hs
+++ b/test/EndToEndSpec.hs
@@ -846,7 +846,7 @@ spec = around_ (inTempDirectoryNamed "my-package") $ do
           |] `shouldRenderTo` (executable_ "my-package" [i|
           build-tools:
               ghc >=7.10
-          |]) { packageWarnings = ["Listing \"ghc\" under build-tools is deperecated! Please list system executables under system-build-tools instead!"] }
+          |]) { packageWarnings = ["Listing \"ghc\" under build-tools is deprecated! Please list system executables under system-build-tools instead!"] }
 
     describe "system-build-tools" $ do
       it "adds system build tools to build-tools" $ do

--- a/test/Hpack/ConfigSpec.hs
+++ b/test/Hpack/ConfigSpec.hs
@@ -166,7 +166,7 @@ spec = do
 
       context "when name matches a legacy system build tool" $ do
         it "warns" $ do
-          toBuildTool_ (UnqualifiedBuildTool "ghc") `shouldBe` (Left ("ghc", AnyVersion), ["Listing \"ghc\" under build-tools is deperecated! Please list system executables under system-build-tools instead!"])
+          toBuildTool_ (UnqualifiedBuildTool "ghc") `shouldBe` (Left ("ghc", AnyVersion), ["Listing \"ghc\" under build-tools is deprecated! Please list system executables under system-build-tools instead!"])
 
     context "with a QualifiedBuildTool" $ do
       context "when only package matches the current package" $ do

--- a/test/Hpack/Syntax/GitSpec.hs
+++ b/test/Hpack/Syntax/GitSpec.hs
@@ -21,7 +21,7 @@ spec = do
     it "rejects .lock at the end of a component" $ do
       isValidRef "foo/bar.lock/baz" `shouldBe` False
 
-    it "rejects . at the biginning of a component" $ do
+    it "rejects . at the beginning of a component" $ do
       isValidRef "foo/.bar/baz" `shouldBe` False
 
     it "rejects two consecutive dots .." $ do


### PR DESCRIPTION
Found via `codespell -L shouldbe,te,characterclasses,fo`