### PR TITLE
Use cryptohash-sha256, not crypton, for SHA256 hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Changes in 0.39.2
+  - Depend on `cryptohash-sha256`, rather than `crypton`, for SHA256 hashes
+
 ## Changes in 0.39.1
   - Add support for `mhs-options` (MicroHs)
 

--- a/hpack.cabal
+++ b/hpack.cabal
@@ -1,11 +1,11 @@
 cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.38.3.
+-- This file has been generated from package.yaml by hpack version 0.39.1.
 --
 -- see: https://github.com/sol/hpack
 
 name:           hpack
-version:        0.39.1
+version:        0.39.2
 synopsis:       A modern format for Haskell packages
 description:    See README at <https://github.com/sol/hpack#readme>
 category:       Development
@@ -71,7 +71,7 @@ library
     , bifunctors
     , bytestring
     , containers
-    , crypton
+    , cryptohash-sha256
     , deepseq
     , directory >=1.2.5.0
     , filepath
@@ -105,7 +105,7 @@ executable hpack
     , bifunctors
     , bytestring
     , containers
-    , crypton
+    , cryptohash-sha256
     , deepseq
     , directory >=1.2.5.0
     , filepath
@@ -203,7 +203,7 @@ test-suite spec
     , bifunctors
     , bytestring
     , containers
-    , crypton
+    , cryptohash-sha256
     , deepseq
     , directory >=1.2.5.0
     , filepath

--- a/package.yaml
+++ b/package.yaml
@@ -1,6 +1,6 @@
 spec-version: 0.36.0
 name: hpack
-version: 0.39.1
+version: 0.39.2
 synopsis: A modern format for Haskell packages
 description: See README at <https://github.com/sol/hpack#readme>
 author: Simon Hengel <sol@typeful.net>
@@ -16,6 +16,7 @@ ghc-options: -Wall -fno-warn-incomplete-uni-patterns
 dependencies:
   - base >= 4.13 && < 5
   - bytestring
+  - cryptohash-sha256
   - deepseq
   - directory >= 1.2.5.0
   - filepath
@@ -29,7 +30,6 @@ dependencies:
   - Cabal >= 3.0.0.0 && < 3.17
   - pretty
   - bifunctors
-  - crypton
   - transformers
   - mtl
   - http-types

--- a/src/Hpack/Util.hs
+++ b/src/Hpack/Util.hs
@@ -32,7 +32,7 @@ import           System.Directory
 import           System.FilePath
 import qualified System.FilePath.Posix as Posix
 import           System.FilePath.Glob
-import           Crypto.Hash
+import qualified Crypto.Hash.SHA256 as SHA256
 
 import           Hpack.Haskell
 import           Hpack.Utf8 as Utf8
@@ -130,7 +130,7 @@ expandGlobs name dir patterns = do
 type Hash = String
 
 sha256 :: String -> Hash
-sha256 c = show (hash (Utf8.encodeUtf8 c) :: Digest SHA256)
+sha256 c = show (SHA256.hash (Utf8.encodeUtf8 c))
 
 nub :: Ord a => [a] -> [a]
 nub = nubOn id


### PR DESCRIPTION
My general motivation is to reduce indirect dependencies on `memory` and `basement` (which are unmaintained) (a goal I have for Stack). This eliminates a dependency on `crypton`.

However, in addition, `hpack` only uses `crypton` for SHA256 hashes. `cryptohash-sha256` is a lightweight package for that single purpose.