### PR TITLE
Re #640 Add an upper bound on crypton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Changes in 0.39.3
+  - Add upper bound `crypton < 1.1`, as dependency `http-client-tls <= 0.3.6.4`
+    does not support `crypton-1.1.0` but does not itself have an upper bound.
+
 ## Changes in 0.39.2
   - Depend on `cryptohash-sha256`, rather than `crypton`, for SHA256 hashes
 

--- a/hpack.cabal
+++ b/hpack.cabal
@@ -5,7 +5,7 @@ cabal-version: 2.0
 -- see: https://github.com/sol/hpack
 
 name:           hpack
-version:        0.39.2
+version:        0.39.3
 synopsis:       A modern format for Haskell packages
 description:    See README at <https://github.com/sol/hpack#readme>
 category:       Development
@@ -72,6 +72,7 @@ library
     , bytestring
     , containers
     , cryptohash-sha256
+    , crypton <1.1
     , deepseq
     , directory >=1.2.5.0
     , filepath
@@ -106,6 +107,7 @@ executable hpack
     , bytestring
     , containers
     , cryptohash-sha256
+    , crypton <1.1
     , deepseq
     , directory >=1.2.5.0
     , filepath
@@ -204,6 +206,7 @@ test-suite spec
     , bytestring
     , containers
     , cryptohash-sha256
+    , crypton <1.1
     , deepseq
     , directory >=1.2.5.0
     , filepath

--- a/package.yaml
+++ b/package.yaml
@@ -1,6 +1,6 @@
 spec-version: 0.36.0
 name: hpack
-version: 0.39.2
+version: 0.39.3
 synopsis: A modern format for Haskell packages
 description: See README at <https://github.com/sol/hpack#readme>
 author: Simon Hengel <sol@typeful.net>
@@ -16,6 +16,7 @@ ghc-options: -Wall -fno-warn-incomplete-uni-patterns
 dependencies:
   - base >= 4.13 && < 5
   - bytestring
+  - crypton < 1.1
   - cryptohash-sha256
   - deepseq
   - directory >= 1.2.5.0


### PR DESCRIPTION
See:
* #640
* #641
* https://github.com/snoyberg/http-client/pull/573

The immediate problem is that direct dependency `http-client-tls <= 0.3.6.4` does not support newly-released `crypton-1.1.0` (an indirect dependency of `hpack`) but does not, itself, specify an upper bound on `crypton`.