### PR TITLE
Re #483 Accept main lib in shorthand syntax for dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Changes in 0.39.5
+  - When rendering build dependencies in a Cabal file, Hpack no longer excludes
+    the reference to the main library from the shorthand syntax such as
+    `my-package:{my-package,my-library1,mylibrary2}`.
+
 ## Changes in 0.39.4
   - Remove upper on `crypton`
 

--- a/hpack.cabal
+++ b/hpack.cabal
@@ -1,11 +1,11 @@
 cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.39.1.
+-- This file has been generated from package.yaml by hpack version 0.38.3.
 --
 -- see: https://github.com/sol/hpack
 
 name:           hpack
-version:        0.39.4
+version:        0.39.5
 synopsis:       A modern format for Haskell packages
 description:    See the README at <https://github.com/sol/hpack#readme>
 category:       Development

--- a/package.yaml
+++ b/package.yaml
@@ -1,6 +1,6 @@
 spec-version: 0.36.0
 name: hpack
-version: 0.39.4
+version: 0.39.5
 synopsis: A modern format for Haskell packages
 description: See the README at <https://github.com/sol/hpack#readme>
 author: Simon Hengel <sol@typeful.net>

--- a/src/Hpack/Syntax/Dependencies.hs
+++ b/src/Hpack/Syntax/Dependencies.hs
@@ -73,10 +73,15 @@ parseDependency :: Fail.MonadFail m => String -> Text -> m (String, DependencyVe
 parseDependency subject = fmap fromCabal . cabalParse subject . T.unpack
   where
     fromCabal :: D.Dependency -> (String, DependencyVersion)
-    fromCabal d = (toName (D.depPkgName d) (DependencySet.toList $ D.depLibraries d), DependencyVersion Nothing . versionConstraintFromCabal $ D.depVerRange d)
+    fromCabal (D.Dependency pkgName verRange libraries) =
+      (depName, DependencyVersion Nothing $ versionConstraintFromCabal verRange)
+      where
+        depName :: String
+        depName = prettyShow pkgName <> case DependencySet.toList libraries of
+          [D.LMainLibName] -> ""
+          [D.LSubLibName name] -> ":" <> prettyShow name
+          xs -> ":{" <> intercalate "," (map renderComponent xs) <> "}"
 
-    toName :: D.PackageName -> [D.LibraryName] -> String
-    toName package components = prettyShow package <> case components of
-      [D.LMainLibName] -> ""
-      [D.LSubLibName lib] -> ":" <> prettyShow lib
-      xs -> ":{" <> (intercalate "," $ map prettyShow [name | D.LSubLibName name <- xs]) <> "}"
+        renderComponent :: D.LibraryName -> String
+        renderComponent D.LMainLibName = prettyShow pkgName
+        renderComponent (D.LSubLibName name) = prettyShow name

--- a/test/Hpack/Syntax/DependenciesSpec.hs
+++ b/test/Hpack/Syntax/DependenciesSpec.hs
@@ -29,6 +29,9 @@ spec = do
     it "accepts dependencies with multiple subcomponents" $ do
       parseDependency "dependency" "foo:{bar,baz}" `shouldReturn` ("foo:{bar,baz}", DependencyVersion Nothing AnyVersion)
 
+    it "accepts dependencies with multiple subcomponents including the main library" $ do
+      parseDependency "dependency" "foo:{foo,bar,baz}" `shouldReturn` ("foo:{foo,bar,baz}", DependencyVersion Nothing AnyVersion)
+
   describe "fromValue" $ do
     context "when parsing Dependencies" $ do
       context "with a scalar" $ do


### PR DESCRIPTION
See:
* https://github.com/sol/hpack/issues/483#issuecomment-1358722897

Currently, something like:
~~~yaml
spec-version: 0.36.0
name: myPackage
dependencies:
- base

library:
  source-dirs: src

internal-libraries:
  sublib1:
    source-dirs: sub1
  sublib2:
    source-dirs: sub2

executables:
  myExe:
    source-dirs: app
    main: Main.hs
    dependencies:
    - myPackage:{myPackage, sublib1, sublib2}
~~~

renders in the Cabal file as (extract):

~~~text
executable myExe
  main-is: Main.hs
  hs-source-dirs:
      app
  build-depends:
      base
    , myPackage:{sublib1,sublib2}   <<<< The reference to the main library component is missing
  default-language: Haskell2010
~~~

This pull request seeks to fix that. A new test is added.