### PR TITLE
Fix #648 Cabal version depends on custom setup deps syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Changes in UNRELEASED
+  - Infer `cabal-version: 3.0` when custom setup has sublibraries as
+    dependencies.
+
 ## Changes in 0.39.6
   - Add support for top-level field `codeberg`
 

--- a/src/Hpack/Config.hs
+++ b/src/Hpack/Config.hs
@@ -836,6 +836,7 @@ ensureRequiredCabalVersion inferredLicense pkg@Package{..} = pkg {
     inferredVersion = fromMaybe packageCabalVersion $ maximum [
         makeVersion [2,2] <$ guard mustSPDX
       , makeVersion [1,24] <$ packageCustomSetup
+      , subLibDepsSyntaxCabalVersion <$ (guard . hasAnySubcomponents . customSetupDependencies =<< packageCustomSetup)
       , makeVersion [1,18] <$ guard (not (null packageExtraDocFiles))
       , makeVersion [3,14] <$ guard (not (null packageExtraFiles))
       , packageLibrary >>= libraryCabalVersion
@@ -844,6 +845,9 @@ ensureRequiredCabalVersion inferredLicense pkg@Package{..} = pkg {
       , executablesCabalVersion packageTests
       , executablesCabalVersion packageBenchmarks
       ]
+
+    hasAnySubcomponents :: Dependencies -> Bool
+    hasAnySubcomponents = any hasSubcomponents . Map.keys . unDependencies
 
     libraryCabalVersion :: Section Library -> Maybe CabalVersion
     libraryCabalVersion sect = maximum [
@@ -867,6 +871,9 @@ ensureRequiredCabalVersion inferredLicense pkg@Package{..} = pkg {
 
     hasPackageInfoModule :: [Module] -> Bool
     hasPackageInfoModule = any (== packageInfoModule)
+
+    subLibDepsSyntaxCabalVersion :: CabalVersion
+    subLibDepsSyntaxCabalVersion = makeVersion [3,0]
 
     internalLibsCabalVersion :: Map String (Section Library) -> Maybe CabalVersion
     internalLibsCabalVersion internalLibraries
@@ -899,7 +906,7 @@ ensureRequiredCabalVersion inferredLicense pkg@Package{..} = pkg {
       , makeVersion [3,0] <$ guard (sectionSatisfies (not . null . sectionAsmOptions) sect)
       , makeVersion [3,0] <$ guard (sectionSatisfies (not . null . sectionAsmSources) sect)
       , makeVersion [2,0] <$ guard (sectionSatisfies (any hasMixins . unDependencies . sectionDependencies) sect)
-      , makeVersion [3,0] <$ guard (sectionSatisfies (any hasSubcomponents . Map.keys . unDependencies . sectionDependencies) sect)
+      , subLibDepsSyntaxCabalVersion <$ guard (sectionSatisfies (hasAnySubcomponents . sectionDependencies) sect)
       , makeVersion [2,2] <$ guard (
               uses "RebindableSyntax"
           && (uses "OverloadedStrings" || uses "OverloadedLists")

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-snapshot: lts-24.6 # GHC 9.10.2
+snapshot: lts-24.44 # GHC 9.10.3

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    sha256: 473840099b95facf73ec72dcafe53a2487bfadeceb03a981a19e16469503a342
-    size: 726266
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/24/6.yaml
-  original: lts-24.6
+    sha256: 78ce76b519082c406415e5070114ad338d8635534c67e85e381abb6676839065
+    size: 728811
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/24/44.yaml
+  original: lts-24.44

--- a/test/EndToEndSpec.hs
+++ b/test/EndToEndSpec.hs
@@ -1300,14 +1300,24 @@ spec = around_ (inTempDirectoryNamed "my-package") $ do
           , "package.yaml: Ignoring unrecognized field $.custom-setup.foo"
           ]
 
-      it "accepts dependencies" $ do
+      it "accepts package dependencies" $ do
         [i|
         custom-setup:
           dependencies:
             - base
-        |] `shouldRenderTo` customSetup [i|
+        |] `shouldRenderTo` customSetupWithCabalVersion "1.24" [i|
         setup-depends:
             base
+        |]
+
+      it "accepts sublibrary dependencies" $ do
+        [i|
+        custom-setup:
+          dependencies:
+            - pkg:lib
+        |] `shouldRenderTo` customSetupWithCabalVersion "3.0" [i|
+        setup-depends:
+            pkg:lib
         |]
 
       it "leaves build-type alone, if it exists" $ do
@@ -1316,7 +1326,7 @@ spec = around_ (inTempDirectoryNamed "my-package") $ do
         custom-setup:
           dependencies:
             - base
-        |] `shouldRenderTo` (customSetup [i|
+        |] `shouldRenderTo` (customSetupWithCabalVersion "1.24" [i|
         setup-depends:
             base
         |]) {packageBuildType = "Make"}
@@ -2179,8 +2189,8 @@ shouldFailWith input expected = do
   writeFile packageConfig input
   run_ "" packageConfig "" `shouldReturn` Left expected
 
-customSetup :: String -> Package
-customSetup a = (package content) {packageCabalVersion = "1.24", packageBuildType = "Custom"}
+customSetupWithCabalVersion :: String -> String -> Package
+customSetupWithCabalVersion cabalVersion a = (package content) {packageCabalVersion = cabalVersion, packageBuildType = "Custom"}
   where
     content = [i|
 custom-setup


### PR DESCRIPTION
See:
* #648

Also bumps the LTS snapshot in `stack.yaml`.

Not set up for immediate release if merged, because a #649 fix (trivial) may go hand-in-hand.