### PR TITLE
Fix #649 cabal-version: 3.4 for sublibrary dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## Changes in UNRELEASED
-  - Infer `cabal-version: 3.0` when custom setup has sublibraries as
-    dependencies.
+## Changes in 0.40.0
+  - Infer `cabal-version: 3.4` (rather than `cabal-version: 3.0`) when a section
+    has sublibraries as dependencies. Make the same inference when custom setup
+    has such dependencies.
 
 ## Changes in 0.39.6
   - Add support for top-level field `codeberg`

--- a/src/Hpack/Config.hs
+++ b/src/Hpack/Config.hs
@@ -873,7 +873,7 @@ ensureRequiredCabalVersion inferredLicense pkg@Package{..} = pkg {
     hasPackageInfoModule = any (== packageInfoModule)
 
     subLibDepsSyntaxCabalVersion :: CabalVersion
-    subLibDepsSyntaxCabalVersion = makeVersion [3,0]
+    subLibDepsSyntaxCabalVersion = makeVersion [3,4]
 
     internalLibsCabalVersion :: Map String (Section Library) -> Maybe CabalVersion
     internalLibsCabalVersion internalLibraries

--- a/test/EndToEndSpec.hs
+++ b/test/EndToEndSpec.hs
@@ -936,7 +936,7 @@ spec = around_ (inTempDirectoryNamed "my-package") $ do
             Paths_my_package
         build-depends:
             foo:bar
-        |]) {packageCabalVersion = "3.0"}
+        |]) {packageCabalVersion = "3.4"}
 
       it "accepts list of dependencies" $ do
         [i|
@@ -1315,7 +1315,7 @@ spec = around_ (inTempDirectoryNamed "my-package") $ do
         custom-setup:
           dependencies:
             - pkg:lib
-        |] `shouldRenderTo` customSetupWithCabalVersion "3.0" [i|
+        |] `shouldRenderTo` customSetupWithCabalVersion "3.4" [i|
         setup-depends:
             pkg:lib
         |]


### PR DESCRIPTION
See:
* #649

This assumes that the change in behaviour for sections requires a major version bump.